### PR TITLE
Fix spelling error in readme/ Added support for OnVehicleDeath and OnVehicleSpawn when SetVehicleUnoccupiedDamage is enabled

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ SetCustomFallDamage(bool:toggle, Float:damage_multiplier = 25.0, Float:death_vel
 Toggle custom falling damage
 
 ```pawn
-SetCustomFallDamageMachines(bool:toggle);
+SetCustomVendingMachines(bool:toggle);
 ```
 Toggle vending machines (they are removed and disabled by default)
 

--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -1355,7 +1355,6 @@ stock WC_CreateVehicle(modelid, Float:x, Float:y, Float:z, Float:angle, color1, 
 	if(id != INVALID_VEHICLE_ID)
 	{
 		s_Vehicle_Alive[id] = true; //Vehicle is alive
-		printf("Created");
 		return id;
 	}
 	return INVALID_VEHICLE_ID;
@@ -1368,7 +1367,6 @@ stock WC_AddStaticVehicle(modelid, Float:x, Float:y, Float:z, Float:angle, color
 	if(id != INVALID_VEHICLE_ID)
 	{
 		s_Vehicle_Alive[id] = true; //Vehicle is alive
-		printf("Created");
 		return id;
 	}
 	return INVALID_VEHICLE_ID;
@@ -1381,7 +1379,6 @@ stock WC_AddStaticVehicleEx(modelid, Float:x, Float:y, Float:z, Float:angle, col
 	if(id != INVALID_VEHICLE_ID)
 	{
 		s_Vehicle_Alive[id] = true; //Vehicle is alive
-		printf("Created");
 		return id;
 	}
 	return INVALID_VEHICLE_ID;

--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -770,6 +770,8 @@ static s_LastVehicleShooter[MAX_VEHICLES + 1] = {INVALID_PLAYER_ID, ...};
 static bool:s_InternalTextDraw[Text:MAX_TEXT_DRAWS];
 static bool:s_InternalPlayerTextDraw[MAX_PLAYERS][PlayerText:MAX_PLAYER_TEXT_DRAWS];
 static s_LastVehicleEnterTime[MAX_PLAYERS];
+static bool:s_Vehicle_Alive[MAX_VEHICLES] = true;
+static s_Vehicle_Respawn_Timer[MAX_VEHICLES] = -1;
 
 native WC_IsValidVehicle(vehicleid) = IsValidVehicle;
 
@@ -1339,12 +1341,52 @@ stock WC_PlayerSpectatePlayer(playerid, targetplayerid, mode = SPECTATE_MODE_NOR
 
 stock WC_DestroyVehicle(vehicleid)
 {
+	s_Vehicle_Alive[vehicleid] = false;
 	if (0 < vehicleid < MAX_VEHICLES) {
 		s_LastVehicleShooter[vehicleid] = INVALID_PLAYER_ID;
 	}
 
 	return DestroyVehicle(vehicleid);
 }
+
+stock WC_CreateVehicle(modelid, Float:x, Float:y, Float:z, Float:angle, color1, color2, respawn_delay)
+{
+	new id = CreateVehicle(modelid, x, y, z, angle, color1, color2, respawn_delay);
+	if(id != INVALID_VEHICLE_ID)
+	{
+		s_Vehicle_Alive[id] = true; //Vehicle is alive
+		printf("Created");
+		return id;
+	}
+	return INVALID_VEHICLE_ID;
+}
+
+
+stock WC_AddStaticVehicle(modelid, Float:x, Float:y, Float:z, Float:angle, color1, color2)
+{
+	new id = AddStaticVehicle(modelid, x, y, z, angle, color1, color2);
+	if(id != INVALID_VEHICLE_ID)
+	{
+		s_Vehicle_Alive[id] = true; //Vehicle is alive
+		printf("Created");
+		return id;
+	}
+	return INVALID_VEHICLE_ID;
+}
+
+
+stock WC_AddStaticVehicleEx(modelid, Float:x, Float:y, Float:z, Float:angle, color1, color2, respawn_delay)
+{
+	new id = AddStaticVehicleEx(modelid, x, y, z, angle, color1, color2, respawn_delay);
+	if(id != INVALID_VEHICLE_ID)
+	{
+		s_Vehicle_Alive[id] = true; //Vehicle is alive
+		printf("Created");
+		return id;
+	}
+	return INVALID_VEHICLE_ID;
+}
+
 
 stock WC_IsPlayerInCheckpoint(playerid)
 {
@@ -2862,18 +2904,16 @@ public OnPlayerWeaponShot(playerid, weaponid, hittype, hitid, Float:fX, Float:fY
 				new Float:health;
 
 				GetVehicleHealth(hitid, health);
-
-				if (WEAPON_SHOTGUN <= weaponid <= WEAPON_SHOTGSPA) {
-					health -= 120.0;
-				} else {
-					health -= s_WeaponDamage[weaponid] * 3.0;
+				if (health >= 250.0)
+				{
+					if (WEAPON_SHOTGUN <= weaponid <= WEAPON_SHOTGSPA) {
+						health -= 120.0;
+					} else {
+						health -= s_WeaponDamage[weaponid] * 3.0;
+					}
+					if(health < 250.0) SetTimerEx("WC_KillVehicle", 6000, false, "ii", hitid,playerid); 
+					SetVehicleHealth(hitid, health);
 				}
-
-				if (health <= 0.0) {
-					health = 0.0;
-				}
-
-				SetVehicleHealth(hitid, health);
 			}
 		}
 	}
@@ -4464,6 +4504,60 @@ public OnPlayerDamage(&playerid, &Float:amount, &issuerid, &weapon, &bodypart)
 	#endif
 }
 
+
+forward WC_KillVehicle(vehicleid,killerid);
+public WC_KillVehicle(vehicleid,killerid)
+{
+	OnVehicleDeath(vehicleid, killerid);
+	s_Vehicle_Respawn_Timer[vehicleid] = SetTimerEx("WC_OnDeadVehicleSpawn", 10000, false, "ii", vehicleid);
+	return 1;
+}
+
+
+forward WC_OnDeadVehicleSpawn(vehicleid);
+public WC_OnDeadVehicleSpawn(vehicleid)
+{
+	s_Vehicle_Respawn_Timer[vehicleid] = -1;
+	return SetVehicleToRespawn(vehicleid);
+}
+
+
+public OnVehicleSpawn(vehicleid)
+{
+	if(s_Vehicle_Respawn_Timer[vehicleid] != -1) 
+	{
+		KillTimer(s_Vehicle_Respawn_Timer[vehicleid]);
+		s_Vehicle_Respawn_Timer[vehicleid] = -1;
+	}
+	if(!s_Vehicle_Alive[vehicleid])
+	{
+		s_Vehicle_Alive[vehicleid] = true;
+		#if defined WC_OnVehicleSpawn
+			return WC_OnVehicleSpawn(vehicleid);
+		#else
+			return 1;
+		#endif
+	}
+	return 1;
+}
+
+
+public OnVehicleDeath(vehicleid, killerid)
+{
+	if(s_Vehicle_Alive[vehicleid])//Checks if the vehicle is alive
+	{
+		s_Vehicle_Alive[vehicleid] = false;
+		#if defined OnVehicleDeath
+			return WC_OnVehicleDeath(vehicleid, killerid);
+		#else
+			return 1;
+		#endif
+	}
+	return 1;
+}
+
+
+
 /*
  * ALS callbacks
  */
@@ -4541,6 +4635,28 @@ public OnPlayerDamage(&playerid, &Float:amount, &issuerid, &weapon, &bodypart)
 #define OnPlayerStreamIn WC_OnPlayerStreamIn
 #if defined WC_OnPlayerStreamIn
 	forward WC_OnPlayerStreamIn(playerid, forplayerid);
+#endif
+
+
+#if defined _ALS_OnVehicleDeath
+	#undef OnVehicleDeath
+#else
+	#define _ALS_OnVehicleDeath
+#endif
+#define OnVehicleDeath WC_OnVehicleDeath
+#if defined WC_OnVehicleDeath
+	forward WC_OnVehicleDeath(vehicleid, killerid);
+#endif
+
+
+#if defined _ALS_OnVehicleSpawn
+	#undef OnVehicleSpawn
+#else
+	#define _ALS_OnVehicleSpawn
+#endif
+#define OnVehicleSpawn WC_OnVehicleSpawn
+#if defined WC_OnVehicleSpawn
+	forward WC_OnVehicleSpawn(vehicleid);
 #endif
 
 
@@ -4891,6 +5007,30 @@ public OnPlayerDamage(&playerid, &Float:amount, &issuerid, &weapon, &bodypart)
 	#define _ALS_DestroyVehicle
 #endif
 #define DestroyVehicle WC_DestroyVehicle
+
+
+#if defined _ALS_CreateVehicle
+	#undef CreateVehicle
+#else
+	#define _ALS_CreateVehicle
+#endif
+#define CreateVehicle WC_CreateVehicle
+
+
+#if defined _ALS_AddStaticVehicle
+	#undef AddStaticVehicle
+#else
+	#define _ALS_AddStaticVehicle
+#endif
+#define AddStaticVehicle WC_AddStaticVehicle
+
+
+#if defined _ALS_AddStaticVehicleEx
+	#undef AddStaticVehicleEx
+#else
+	#define _ALS_AddStaticVehicleEx
+#endif
+#define AddStaticVehicleEx WC_AddStaticVehicleEx
 
 
 #if defined _ALS_IsPlayerInCheckpoint


### PR DESCRIPTION
Fixed a spelling mistake in the readme. 
Changed SetCustomFallDamageMachines(bool:toggle); to SetCustomVendingMachines(bool:toggle);

Fixed a bug with SetVehicleUnoccupiedDamage where vehicles would not call OnVehicleDeath and OnVehicleSpawn after they vehicle has exploded. 

To reproduce the original bug simply spawn a vehicle and then enter and exit the vehicle, shoot the vehicle until it explodes, this vehicle will call appropriate functions and re-spawn as normal. Once the vehicle re-spawns do not enter it. Shoot the vehicle again until it explodes making sure that no player has entered the vehicle since it re-spawned, the vehicle will now disappear and will not re-spawn. 

With the new addition vehicles that have never been occupied by players since it first spawned/respawned, and then were shot until they explode, will now call OnVehicleDeath when they explode and will call OnVehicleSpawn when they re-spawn.

I am not sure if this is the best way to do it, but it works flawlessly so far on my server.

