### PR TITLE
Adding the `ignore_armour` boolean to `DamagePlayer` and `InflictDama…

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,9 +195,10 @@ AverageHitRate(playerid, hits, &multiple_weapons = 0);
 Same as above, but for hits inflicted with `OnPlayerGiveDamage`
 
 ```pawn
-DamagePlayer(playerid, Float:amount, issuerid = INVALID_PLAYER_ID, weaponid = WEAPON_UNKNOWN, bodypart = BODY_PART_UNKNOWN);
+DamagePlayer(playerid, Float:amount, issuerid = INVALID_PLAYER_ID, weaponid = WEAPON_UNKNOWN, bodypart = BODY_PART_UNKNOWN, bool:ignore_armour = false);
 ```
 Inflict a hit on a player. All callbacks except `OnPlayerWeaponShot` will be called.
+* `ignore_armour` - When `true` will do damage straight to health, and not armour.
 
 ```pawn
 Float:GetPlayerHealth(playerid, &Float:health = 0.0);

--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -1182,7 +1182,7 @@ stock Float:GetLastDamageArmour(playerid)
 	return 0.0;
 }
 
-stock DamagePlayer(playerid, Float:amount, issuerid = INVALID_PLAYER_ID, weaponid = WEAPON_UNKNOWN, bodypart = BODY_PART_UNKNOWN)
+stock DamagePlayer(playerid, Float:amount, issuerid = INVALID_PLAYER_ID, weaponid = WEAPON_UNKNOWN, bodypart = BODY_PART_UNKNOWN, bool:ignore_armour = false)
 {
 	if (playerid < 0 || playerid > MAX_PLAYERS || !IsPlayerConnected(playerid)) {
 		return 0;
@@ -1200,7 +1200,7 @@ stock DamagePlayer(playerid, Float:amount, issuerid = INVALID_PLAYER_ID, weaponi
 		issuerid = INVALID_PLAYER_ID;
 	}
 
-	InflictDamage(playerid, amount, issuerid, weaponid, bodypart);
+	InflictDamage(playerid, amount, issuerid, weaponid, bodypart, bool:ignore_armour);
 
 	return 1;
 }
@@ -4470,7 +4470,7 @@ static ProcessDamage(&playerid, &issuerid, &Float:amount, &weaponid, &bodypart, 
 	return WC_NO_ERROR;
 }
 
-static InflictDamage(playerid, Float:amount, issuerid = INVALID_PLAYER_ID, weaponid = WEAPON_UNKNOWN, bodypart = BODY_PART_UNKNOWN)
+static InflictDamage(playerid, Float:amount, issuerid = INVALID_PLAYER_ID, weaponid = WEAPON_UNKNOWN, bodypart = BODY_PART_UNKNOWN, bool:ignore_armour = false)
 {
 	if (!IsPlayerSpawned(playerid) || amount < 0.0) {
 		return;
@@ -4518,7 +4518,7 @@ static InflictDamage(playerid, Float:amount, issuerid = INVALID_PLAYER_ID, weapo
 		}
 	#endif
 
-	if (weaponid == WEAPON_COLLISION || weaponid == WEAPON_DROWN || weaponid == WEAPON_CARPARK) {
+	if (weaponid == WEAPON_COLLISION || weaponid == WEAPON_DROWN || weaponid == WEAPON_CARPARK || bool:ignore_armour) {
 		if (amount <= 0.0) {
 			amount = s_PlayerHealth[playerid];
 		}

--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -1200,7 +1200,7 @@ stock DamagePlayer(playerid, Float:amount, issuerid = INVALID_PLAYER_ID, weaponi
 		issuerid = INVALID_PLAYER_ID;
 	}
 
-	InflictDamage(playerid, amount, issuerid, weaponid, bodypart, bool:ignore_armour);
+	InflictDamage(playerid, amount, issuerid, weaponid, bodypart, ignore_armour);
 
 	return 1;
 }
@@ -4518,7 +4518,7 @@ static InflictDamage(playerid, Float:amount, issuerid = INVALID_PLAYER_ID, weapo
 		}
 	#endif
 
-	if (weaponid == WEAPON_COLLISION || weaponid == WEAPON_DROWN || weaponid == WEAPON_CARPARK || bool:ignore_armour) {
+	if (weaponid == WEAPON_COLLISION || weaponid == WEAPON_DROWN || weaponid == WEAPON_CARPARK || ignore_armour) {
 		if (amount <= 0.0) {
 			amount = s_PlayerHealth[playerid];
 		}


### PR DESCRIPTION
…ge` to do damage straight to health, ignoring armour.

Please do check if the code is sane, I have my doubts that [this](https://github.com/oscar-broman/samp-weapon-config/compare/master...Jeroen52:master#diff-bb9c2a9539291b896d938b65a38c33e9R1203) is sane.

Made this pull request because of this: http://forum.sa-mp.com/showpost.php?p=3622195&postcount=380