### PR TITLE
This function in the README.md had the wrong name for a long time, this commit fixes that.

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,7 +266,7 @@ SetCustomFallDamage(bool:toggle, Float:damage_multiplier = 25.0, Float:death_vel
 Toggle custom falling damage
 
 ```pawn
-SetCustomFallDamageMachines(bool:toggle);
+SetCustomVendingMachines(bool:toggle);
 ```
 Toggle vending machines (they are removed and disabled by default)
 


### PR DESCRIPTION
As the title says, there was a function that was written incorrectly in the README file.