### PR TITLE
Update weapon-config.inc

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,16 @@ SetCustomVendingMachines(bool:toggle);
 Toggle vending machines (they are removed and disabled by default)
 
 ```pawn
+SetCbugAllowed(bool:enabled,playerid = INVALID_PLAYER_ID);
+```
+Toggle anti-cbug per player or globally. (Using no playerid param will default all users to default)
+
+```pawn
+bool:GetCbugAllowed(playerid = INVALID_PLAYER_ID);
+```
+Check if users anti-cbug is toggled. (Using no playerid param will show the global toggle value)
+
+```pawn
 SetDamageFeed(bool:toggle);
 ```
 Toggle damage feed

--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -3221,6 +3221,7 @@ public OnPlayerGiveDamage(playerid, damagedid, Float:amount, weaponid, bodypart)
 
 public OnPlayerTakeDamage(playerid, issuerid, Float:amount, weaponid, bodypart)
 {
+	if(playerid==INVALID_PLAYER_ID || IsPlayerNPC(playerid)) return 0;
 	UpdateHealthBar(playerid, true);
 
 	if (s_IsDying[playerid]) {
@@ -3237,10 +3238,6 @@ public OnPlayerTakeDamage(playerid, issuerid, Float:amount, weaponid, bodypart)
 
 	// Ignore unreliable and invalid damage
 	if (weaponid < 0 || weaponid >= sizeof(s_ValidDamageTaken) || !s_ValidDamageTaken[weaponid]) {
-		return 0;
-	}
-
-	if (playerid == INVALID_PLAYER_ID || IsPlayerNPC(playerid)) {
 		return 0;
 	}
 

--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -977,7 +977,7 @@ stock AverageShootRate(playerid, shots, &multiple_weapons = 0)
 
 		total += s_LastShotTicks[playerid][this_idx] - prev;
 	}
-
+	if(shots==1) return 1;
 	return total / (shots - 1);
 }
 
@@ -1014,7 +1014,7 @@ stock AverageHitRate(playerid, hits, &multiple_weapons = 0)
 
 		total += s_LastHitTicks[playerid][this_idx] - prev;
 	}
-
+	if(hits==1) return 1;
 	return total / (hits - 1);
 }
 

--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -836,7 +836,8 @@ static bool:s_HealthBarVisible[MAX_PLAYERS];
 static bool:s_SpawnForStreamedIn[MAX_PLAYERS];
 static s_RespawnTime = 3000;
 static s_CustomFallDamage = false;
-static bool:s_CbugAllowed = true;
+static bool:s_CbugGlobal = true;
+static bool:s_CbugAllowed[MAX_PLAYERS] = true;
 static s_CbugFroze[MAX_PLAYERS];
 static s_DamageFeed = true;
 static s_DamageFeedPlayer[MAX_PLAYERS] = {-1, ...};
@@ -1104,14 +1105,28 @@ stock SetDamageSounds(taken, given)
 	s_DamageGivenSound = given;
 }
 
-stock SetCbugAllowed(bool:enabled)
+stock SetCbugAllowed(bool:enabled,playerid = INVALID_PLAYER_ID)
 {
-	s_CbugAllowed = enabled;
+	if (playerid == INVALID_PLAYER_ID) {
+		for (new i = 0; i < MAX_PLAYERS; i++) {
+			if (IsPlayerConnected(i)) {
+				s_CbugAllowed[i] = enabled;
+				s_CbugGlobal = enabled;
+			}
+		}
+	}
+	else {
+		s_CbugAllowed[playerid] = enabled;
+	}
+	return enabled;
 }
 
-stock bool:GetCbugAllowed()
+stock bool:GetCbugAllowed(playerid = INVALID_PLAYER_ID)
 {
-	return s_CbugAllowed;
+	if (playerid == INVALID_PLAYER_ID) {
+		return s_CbugGlobal;
+	}
+	return s_CbugAllowed[playerid];
 }
 
 stock SetCustomFallDamage(bool:toggle, Float:damage_multiplier = 25.0, Float:death_velocity = -0.6)
@@ -2602,7 +2617,7 @@ public WC_CbugPunishment(playerid, weapon) {
 
 public OnPlayerKeyStateChange(playerid, newkeys, oldkeys)
 {
-	if (!s_CbugAllowed && !IsPlayerDying(playerid) && GetPlayerState(playerid) == PLAYER_STATE_ONFOOT) {
+	if (!s_CbugAllowed[playerid] && !IsPlayerDying(playerid) && GetPlayerState(playerid) == PLAYER_STATE_ONFOOT) {
 		if (newkeys & KEY_CROUCH) {
 			new tick = GetTickCount();
 			new diff = tick - s_LastShot[playerid][e_Tick];
@@ -4755,7 +4770,7 @@ static InflictDamage(playerid, Float:amount, issuerid = INVALID_PLAYER_ID, weapo
 		}
 
 		#if defined WC_OnPlayerDeath
-			if (s_CbugAllowed) {
+			if (s_CbugAllowed[playerid]) {
 				WC_OnPlayerDeath(playerid, issuerid, weaponid);
 			} else {
 				s_DelayedDeathTimer[playerid] = SetTimerEx(#WC_DelayedDeath, 1200, false, "iii", playerid, issuerid, weaponid);


### PR DESCRIPTION
The array is being accessed out of array is an array that is maxed with MAX_PLAYERS

UpdateHealthBar isn't protected from it, thus I think is the cause.
```
03/17/18 20:30:48 [debug] Run time error 4: "Array index out of bounds"
03/17/18 20:30:48 [debug]  Accessing element at index 65535 past array upper bound 199
03/17/18 20:30:48 [debug] AMX backtrace:
03/17/18 20:30:48 [debug] #0 006dd428 in ?? (65535, 5, 19, 49, 1111883777, 0, 0) from b8.amx
03/17/18 20:30:48 [debug] #1 006d0b14 in ?? (5, 65535, 1111883777, 49, 3) from b8.amx
03/17/18 20:30:48 [debug] #2 0000bb24 in public OnPlayerTakeDamage (5, 65535, 1111883777, 49, 3) from b8.amx
03/17/18 20:30:48 [debug] Run time error 4: "Array index out of bounds"
03/17/18 20:30:48 [debug]  Accessing element at index 65535 past array upper bound 199
03/17/18 20:30:48 [debug] AMX backtrace:
03/17/18 20:30:48 [debug] #0 006dd428 in ?? (65535, 5, 19, 49, 1111883777, 0, 0) from b8.amx
03/17/18 20:30:48 [debug] #1 006d0b14 in ?? (5, 65535, 1111883777, 49, 3) from b8.amx
03/17/18 20:30:48 [debug] #2 0000bb24 in public OnPlayerTakeDamage (5, 65535, 1111883777, 49, 3) from b8.amx
03/17/18 20:30:54 [debug] Run time error 4: "Array index out of bounds"
03/17/18 20:30:54 [debug]  Accessing element at index 65535 past array upper bound 199
03/17/18 20:30:54 [debug] AMX backtrace:
03/17/18 20:30:54 [debug] #0 006dd428 in ?? (65535, 5, 19, 49, 1111883777, 0, 0) from b8.amx
03/17/18 20:30:54 [debug] #1 006d0b14 in ?? (5, 65535, 1111883777, 49, 3) from b8.amx
03/17/18 20:30:54 [debug] #2 0000bb24 in public OnPlayerTakeDamage (5, 65535, 1111883777, 49, 3) from b8.amx
```
199 = I set MAX_PLAYERS to 200.

