### PR TITLE
Update weapon-config.inc

### DIFF
--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -977,7 +977,7 @@ stock AverageShootRate(playerid, shots, &multiple_weapons = 0)
 
 		total += s_LastShotTicks[playerid][this_idx] - prev;
 	}
-
+	if(shots==1) return 0;
 	return total / (shots - 1);
 }
 

--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -977,7 +977,7 @@ stock AverageShootRate(playerid, shots, &multiple_weapons = 0)
 
 		total += s_LastShotTicks[playerid][this_idx] - prev;
 	}
-	if(shots==1) return 0;
+	if(shots==1) return 1;
 	return total / (shots - 1);
 }
 
@@ -1014,7 +1014,7 @@ stock AverageHitRate(playerid, hits, &multiple_weapons = 0)
 
 		total += s_LastHitTicks[playerid][this_idx] - prev;
 	}
-
+	if(hits==1) return 1;
 	return total / (hits - 1);
 }
 


### PR DESCRIPTION
Numbers cannot be divided by zero in Pawn, if shots = 0 then crashdetect will output crash data.

otherwise
http://forum.sa-mp.com/showpost.php?p=4004632&postcount=736