### PR TITLE
Critical fix and a little improvement

### DIFF
--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -3278,6 +3278,10 @@ public OnPlayerTakeDamage(playerid, issuerid, Float:amount, weaponid, bodypart)
 		return 0;
 	}
 
+	if (s_InClassSelection[playerid] || s_ForceClassSelection[playerid]) {
+		return 0;
+	}
+
 	if (!IsHighRateWeapon(weaponid)) {
 		DebugMessage(playerid, "OnPlayerTakeDamage(%d took %f from %d by %d on bodypart %d)", playerid, amount, issuerid, weaponid, bodypart);
 	}
@@ -3313,10 +3317,6 @@ public OnPlayerTakeDamage(playerid, issuerid, Float:amount, weaponid, bodypart)
 
 	// Being knifed client-side
 	if (weaponid == WEAPON_KNIFE) {
-		if (s_IsDying[playerid]) {
-			return 0;
-		}
-
 		// With the plugin, this part is never actually used (it can't happen)
 		if (_:amount == _:0.0) {
 			if (s_KnifeTimeout[playerid] != -1) {


### PR DESCRIPTION
1. Prevented an ability of death flood by calling take damage (with a great amount to send it only one time, for example) and then calling request class event (which resets s_IsDying variable so that OnPlayerDeath can be called immediately again and again).
2. Removed a duplicate check for player's death in OnPlayerTakeDamage