### PR TITLE
Fix SetPlayerTeam and vehicle friendly fire (#128)

### DIFF
--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -3956,13 +3956,7 @@ static ScriptInit()
 		}
 	#endif
 
-		new team = GetPlayerTeam(playerid);
-
-		if (team == 0xFE) {
-			s_PlayerTeam[playerid] = NO_TEAM;
-		} else {
-			s_PlayerTeam[playerid] = team;
-		}
+		s_PlayerTeam[playerid] = GetPlayerTeam(playerid);
 
 		SetPlayerTeam(playerid, s_PlayerTeam[playerid]);
 		DamageFeedUpdate(playerid);

--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -2213,7 +2213,7 @@ public OnPlayerConnect(playerid)
 		s_DamageFeedHitsTaken[playerid][i][e_Tick] = 0;
 	}
 
-	SetPlayerTeam(playerid, 0xFE);
+	SetPlayerTeam(playerid, s_PlayerTeam[playerid]);
 	FreezeSyncPacket(playerid, .toggle = false);
 	SetFakeFacingAngle(playerid, _);
 	DamageFeedUpdate(playerid);
@@ -2421,8 +2421,8 @@ public OnPlayerSpawn(playerid)
 	SetFakeFacingAngle(playerid, _);
 	DamageFeedUpdate(playerid);
 
-	if (GetPlayerTeam(playerid) != 0xFE) {
-		SetPlayerTeam(playerid, 0xFE);
+	if (GetPlayerTeam(playerid) != s_PlayerTeam[playerid]) {
+		SetPlayerTeam(playerid, s_PlayerTeam[playerid]);
 	}
 
 	if (s_DeathSkip[playerid] == 2) {
@@ -2658,10 +2658,10 @@ public OnPlayerDeath(playerid, killerid, reason)
 			s_DeathSkip[playerid] = 2;
 
 			ForceClassSelection(playerid);
-			SetSpawnInfo(playerid, 0xFE, GetPlayerSkin(playerid), x, y, z, r, 0, 0, 0, 0, 0, 0);
+			SetSpawnInfo(playerid, /*0xFE*/s_PlayerTeam[playerid], GetPlayerSkin(playerid), x, y, z, r, 0, 0, 0, 0, 0, 0);
 			TogglePlayerSpectating(playerid, true);
 			TogglePlayerSpectating(playerid, false);
-			SetSpawnInfo(playerid, 0xFE, GetPlayerSkin(playerid), x, y, z, r, 0, 0, 0, 0, 0, 0);
+			SetSpawnInfo(playerid, /*0xFE*/s_PlayerTeam[playerid], GetPlayerSkin(playerid), x, y, z, r, 0, 0, 0, 0, 0, 0);
 			TogglePlayerControllable(playerid, true);
 			GivePlayerWeapon(playerid, 1, 1);
 		} else {
@@ -2962,7 +2962,7 @@ public OnPlayerUpdate(playerid)
 				GetPlayerPos(playerid, x, y, z);
 				GetPlayerFacingAngle(playerid, r);
 
-				SetSpawnInfo(playerid, 0xFE, GetPlayerSkin(playerid), x, y, z, r, 0, 0, 0, 0, 0, 0);
+				SetSpawnInfo(playerid, /*0xFE*/s_PlayerTeam[playerid], GetPlayerSkin(playerid), x, y, z, r, 0, 0, 0, 0, 0, 0);
 
 				s_DeathSkipTick[playerid] = 0;
 
@@ -3964,7 +3964,7 @@ static ScriptInit()
 			s_PlayerTeam[playerid] = team;
 		}
 
-		SetPlayerTeam(playerid, 0xFE);
+		SetPlayerTeam(playerid, s_PlayerTeam[playerid]);
 		DamageFeedUpdate(playerid);
 
 		new worldid = GetPlayerVirtualWorld(playerid);
@@ -4244,7 +4244,7 @@ static SpawnPlayerInPlace(playerid) {
 	GetPlayerPos(playerid, x, y, z);
 	GetPlayerFacingAngle(playerid, r);
 
-	SetSpawnInfo(playerid, 0xFE, GetPlayerSkin(playerid), x, y, z, r, 0, 0, 0, 0, 0, 0);
+	SetSpawnInfo(playerid, /*0xFE*/s_PlayerTeam[playerid], GetPlayerSkin(playerid), x, y, z, r, 0, 0, 0, 0, 0, 0);
 
 	s_SpawnInfoModified[playerid] = true;
 

--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -2658,10 +2658,10 @@ public OnPlayerDeath(playerid, killerid, reason)
 			s_DeathSkip[playerid] = 2;
 
 			ForceClassSelection(playerid);
-			SetSpawnInfo(playerid, /*0xFE*/s_PlayerTeam[playerid], GetPlayerSkin(playerid), x, y, z, r, 0, 0, 0, 0, 0, 0);
+			SetSpawnInfo(playerid, s_PlayerTeam[playerid], GetPlayerSkin(playerid), x, y, z, r, 0, 0, 0, 0, 0, 0);
 			TogglePlayerSpectating(playerid, true);
 			TogglePlayerSpectating(playerid, false);
-			SetSpawnInfo(playerid, /*0xFE*/s_PlayerTeam[playerid], GetPlayerSkin(playerid), x, y, z, r, 0, 0, 0, 0, 0, 0);
+			SetSpawnInfo(playerid, s_PlayerTeam[playerid], GetPlayerSkin(playerid), x, y, z, r, 0, 0, 0, 0, 0, 0);
 			TogglePlayerControllable(playerid, true);
 			GivePlayerWeapon(playerid, 1, 1);
 		} else {
@@ -2962,7 +2962,7 @@ public OnPlayerUpdate(playerid)
 				GetPlayerPos(playerid, x, y, z);
 				GetPlayerFacingAngle(playerid, r);
 
-				SetSpawnInfo(playerid, /*0xFE*/s_PlayerTeam[playerid], GetPlayerSkin(playerid), x, y, z, r, 0, 0, 0, 0, 0, 0);
+				SetSpawnInfo(playerid, s_PlayerTeam[playerid], GetPlayerSkin(playerid), x, y, z, r, 0, 0, 0, 0, 0, 0);
 
 				s_DeathSkipTick[playerid] = 0;
 
@@ -4244,7 +4244,7 @@ static SpawnPlayerInPlace(playerid) {
 	GetPlayerPos(playerid, x, y, z);
 	GetPlayerFacingAngle(playerid, r);
 
-	SetSpawnInfo(playerid, /*0xFE*/s_PlayerTeam[playerid], GetPlayerSkin(playerid), x, y, z, r, 0, 0, 0, 0, 0, 0);
+	SetSpawnInfo(playerid, s_PlayerTeam[playerid], GetPlayerSkin(playerid), x, y, z, r, 0, 0, 0, 0, 0, 0);
 
 	s_SpawnInfoModified[playerid] = true;
 


### PR DESCRIPTION
Fixes #128. Running this piece of code on my server since almost a week now, no issues and works completely fine.

Now using `EnableVehicleFriendlyFire();` should lets you shoot enemy vehicles and keeps your own team vehicles safe and sound.