### PR TITLE
bug fix (#146)

### DIFF
--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -1508,6 +1508,7 @@ stock WC_SetPlayerTeam(playerid, team)
 	}
 
 	s_PlayerTeam[playerid] = team;
+	SetPlayerTeam(playerid, team);
 
 	return 1;
 }


### PR DESCRIPTION
Fixes a bug where setting player team on spawn didn't change it.  this should fix bug related to damaging team vehicles on foot and with vehicles such as hydra/ rhino.

((thanks to @RodrigoMSR for the issue))