### PR TITLE
Little corrections of IDs validity checking

### DIFF
--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -3070,11 +3070,6 @@ public OnPlayerUpdate(playerid)
 
 public OnPlayerGiveDamage(playerid, damagedid, Float:amount, weaponid, bodypart)
 {
-	if(!IsPlayerConnected(playerid))
-	{
-		return 0;
-	}
-
 	if (!IsHighRateWeapon(weaponid)) {
 		DebugMessage(playerid, "OnPlayerGiveDamage(%d gave %f to %d using %d on bodypart %d)", playerid, amount, damagedid, weaponid, bodypart);
 	}
@@ -3322,7 +3317,7 @@ public OnPlayerGiveDamage(playerid, damagedid, Float:amount, weaponid, bodypart)
 
 public OnPlayerTakeDamage(playerid, issuerid, Float:amount, weaponid, bodypart)
 {
-	if (!IsPlayerConnected(playerid) || IsPlayerNPC(playerid)) {
+	if (IsPlayerNPC(playerid)) {
 		return 0;
 	}
 


### PR DESCRIPTION
According to [this](https://github.com/oscar-broman/samp-weapon-config/commit/f6acd01ac9f9c33b05a2c9f1cc56a443fa9937a4) and [this](https://github.com/oscar-broman/samp-weapon-config/commit/23fd2328ec65a667b1e2391d8ed504ca7a5778ce) commits, weapon-config started to check `playerid` parameter of publics OnPlayer(Give/Take)Damage for validity. The other checks is needed, but `playerid` can't be sent as invalid just because the client cannot influence this. He can spoof only `damagedid` in GiveDamage event and `issuerid` in TakeDamage event.