### PR TITLE
Set vehicle shooter to invalid on vehicle respawn

### DIFF
--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -3749,6 +3749,7 @@ public OnVehicleSpawn(vehicleid)
 	}
 
 	s_VehicleAlive[vehicleid] = true;
+	s_LastVehicleShooter[vehicleid] = INVALID_PLAYER_ID;
 
 	return WC_OnVehicleSpawn(vehicleid);
 }


### PR DESCRIPTION
Fixes the issue where if your vehicle blows up, it will mark the old shooter as the killerid.