### PR TITLE
Additional check in OnPlayerGiveDamage

### DIFF
--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -3151,6 +3151,11 @@ public OnPlayerGiveDamage(playerid, damagedid, Float:amount, weaponid, bodypart)
 		return 0;
 	}
 
+	// Driver doesn't call this even if he damage someone
+	if (GetPlayerState(playerid) == PLAYER_STATE_DRIVER) {
+		return 0;
+	}
+
 	new Float:bullets, err;
 
 	if ((err = ProcessDamage(damagedid, playerid, amount, weaponid, bodypart, bullets))) {

--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -4664,7 +4664,7 @@ static InflictDamage(playerid, Float:amount, issuerid = INVALID_PLAYER_ID, weapo
 		}
 	#endif
 
-	if (!ignore_armour && weaponid != WEAPON_COLLISION && weaponid != WEAPON_DROWN && weaponid != WEAPON_CARPARK && weaponid != WEAPON_UNKNOWN 
+	if (!ignore_armour && weaponid != WEAPON_COLLISION && weaponid != WEAPON_DROWN && weaponid != WEAPON_CARPARK && weaponid != WEAPON_UNKNOWN
 	&& (!s_DamageArmourToggle[0] || (s_DamageArmour[weaponid][0] && (!s_DamageArmourToggle[1] || ((s_DamageArmour[weaponid][1] && bodypart == 3) || (!s_DamageArmour[weaponid][1])))))) {
 		if (amount <= 0.0) {
 			amount = s_PlayerHealth[playerid] + s_PlayerArmour[playerid];

--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -1568,7 +1568,7 @@ stock WC_GetWeaponName(weaponid, weapon[], len = sizeof(weapon))
 	return 1;
 }
 
-stock WC_ApplyAnimation(playerid, const animlib[], const animname[], Float:fDelta, loop, lockx, locky, freeze, time, forcesync = 0)
+stock WC_ApplyAnimation(playerid, WC_CONST animlib[], WC_CONST animname[], Float:fDelta, loop, lockx, locky, freeze, time, forcesync = 0)
 {
 	if (playerid < 0 || playerid >= MAX_PLAYERS || s_IsDying[playerid]) {
 		return 0;


### PR DESCRIPTION
There are some fixes and other minor corrections. The main is additional check in OnPlayerGiveDamage for player state driver (if player is a driver, he doesn't send this callback and it can help to prevent hacks that spoof OnPlayerGiveDamage this way). Also I've added WC_CONST instead of just 'const' for ApplyAnimation hook. Seems like its needed here too.