### PR TITLE
Add support for non-y_iterate lib gamemode.

### DIFF
--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -50,11 +50,6 @@
 	#define WC_CUSTOM_VENDING_MACHINES true
 #endif
 
-// YSI Packages by default is turn on, if someone not use this package he can turn off it.
-#if !defined WC_YSI_PACKAGE
-	#define WC_YSI_PACKAGE true
-#endif
-
 #if WC_USE_STREAMER && !defined Streamer_IncludeFileVersion
 	#error streamer.inc is required when WC_USE_STREAMER=true
 #endif
@@ -67,15 +62,11 @@
 		#error The SKY plugin is required, get it here: github.com/oscar-broman/sky
 	#endif
 #endif
-#if !defined _inc_y_iterate
-	#if WC_YSI_PACKAGE == true
-	#tryinclude <YSI_Data\y_iterate>
 
-	#if !defined _inc_y_iterate
-		#error #error the YSI library is required, get it here: github.com/pawn-lang/YSI-Includes
-	#endif
-	#endif
+#if !defined _inc_y_iterate
+	#tryinclude <YSI_Data\y_iterate>
 #endif
+
 // Pre-hooks for hooking callbacks
 #if !defined CHAIN_ORDER
 	#define CHAIN_ORDER() 0
@@ -1158,12 +1149,12 @@ stock SetCbugAllowed(bool:enabled, playerid = INVALID_PLAYER_ID)
 {
 	if (playerid == INVALID_PLAYER_ID) {
 		s_CbugGlobal = enabled;
-		#if WC_YSI_PACKAGE == true
-		foreach (new i : Player) {		
-		#else
+		#if defined _inc_y_iterate
+		foreach (new i : Player) {
+		#else 
 		for (new i = GetPlayerPoolSize(); i != -1; i--) {
-		#endif	
-		s_CbugAllowed[i] = enabled;	
+		#endif
+			s_CbugAllowed[i] = enabled;
 		}
 	} else {
 		s_CbugAllowed[playerid] = enabled;
@@ -1239,10 +1230,10 @@ stock SetDamageFeed(bool:toggle)
 {
 	s_DamageFeed = toggle;
 
-	#if WC_YSI_PACKAGE == true
+	#if defined _inc_y_iterate
 	foreach (new i : Player) {
-	#else
-	for (new i = GetPlayerPoolSize(); i != -1; i--) {		
+	#else 
+	for (new i = GetPlayerPoolSize(); i != -1; i--) {
 	#endif
 		DamageFeedUpdate(i);
 	}
@@ -2308,18 +2299,20 @@ public OnPlayerDisconnect(playerid, reason)
 
 	for (new i = 0; i < sizeof(s_InternalPlayerTextDraw[]); i++) {
 		s_InternalPlayerTextDraw[playerid][PlayerText:i] = false;
-	}	
-	#if WC_YSI_PACKAGE == true
+	}
+
+	#if defined _inc_y_iterate
 	foreach (new i : Player) {
-	#else
+	#else 
 	for (new i = GetPlayerPoolSize(); i != -1; i--) {
-	#endif	
+	#endif
 		for (new j = 0; j < sizeof(s_PreviousHits[]); j++) {
 			if (s_PreviousHits[i][j][e_Issuer] == playerid) {
 				s_PreviousHits[i][j][e_Issuer] = INVALID_PLAYER_ID;
 			}
-		}	
+		}
 	}
+
 	return 1;
 }
 
@@ -2714,11 +2707,12 @@ public OnPlayerKeyStateChange(playerid, newkeys, oldkeys)
 				SetTimerEx("WC_CbugPunishment", 600, false, "ii", playerid, GetPlayerWeapon(playerid));
 
 				s_CbugFroze[playerid] = tick;
-				#if WC_YSI_PACKAGE == true	
+
+				#if defined _inc_y_iterate
 				foreach (new i : Player) {
-				#else
+				#else 
 				for (new i = GetPlayerPoolSize(); i != -1; i--) {
-				#endif	
+				#endif
 					for (new j = 0; j < sizeof(s_PreviousHits[]); j++) {
 						if (s_PreviousHits[i][j][e_Issuer] == playerid && tick - s_PreviousHits[i][j][e_Tick] <= 1200) {
 							s_PreviousHits[i][j][e_Issuer] = INVALID_PLAYER_ID;
@@ -2880,11 +2874,11 @@ public OnPlayerStateChange(playerid, newstate, oldstate)
 			GetPlayerVelocity(playerid, vx, vy, vz);
 
 			if (vx*vx + vy*vy + vz*vz <= 0.05) {
-					#if WC_YSI_PACKAGE == true
-					foreach (new i : Player) {
-					#else
-					for (new i = GetPlayerPoolSize(); i != -1; i--) {
-					#endif
+				#if defined _inc_y_iterate
+				foreach (new i : Player) {
+				#else 
+				for (new i = GetPlayerPoolSize(); i != -1; i--) {
+				#endif
 					if (i != playerid && IsPlayerStreamedIn(playerid, i)) {
 						SendLastSyncPacket(playerid, i);
 						ClearAnimationsForPlayer(playerid, i);
@@ -3652,9 +3646,9 @@ public OnPlayerWeaponShot(playerid, weaponid, hittype, hitid, Float:fX, Float:fY
 			new has_driver = false;
 			new has_passenger = false;
 
-			#if WC_YSI_PACKAGE == true
+			#if defined _inc_y_iterate
 			foreach (new otherid : Player) {
-			#else
+			#else 
 			for (new otherid = GetPlayerPoolSize(); otherid != -1; otherid--) {
 			#endif
 				if (otherid == playerid) {
@@ -3696,9 +3690,9 @@ public OnPlayerWeaponShot(playerid, weaponid, hittype, hitid, Float:fX, Float:fY
 		if (s_VehicleUnoccupiedDamage) {
 			new has_occupent = false;
 
-			#if WC_YSI_PACKAGE == true
+			#if defined _inc_y_iterate
 			foreach (new otherid : Player) {
-			#else
+			#else 
 			for (new otherid = GetPlayerPoolSize(); otherid != -1; otherid--) {
 			#endif
 				if (otherid == playerid) {
@@ -3871,9 +3865,9 @@ static ScriptInit()
 
 	new tick = GetTickCount();
 
-	#if WC_YSI_PACKAGE == true
+	#if defined _inc_y_iterate
 	foreach (new playerid : Player) {
-	#else
+	#else 
 	for (new playerid = GetPlayerPoolSize(); playerid != -1; playerid--) {
 	#endif
 		s_PlayerTeam[playerid] = GetPlayerTeam(playerid);
@@ -3937,9 +3931,9 @@ static ScriptExit()
 		DestroyVendingMachines();
 	#endif
 
-	#if WC_YSI_PACKAGE == true
+	#if defined _inc_y_iterate
 	foreach (new playerid : Player) {
-	#else
+	#else 
 	for (new playerid = GetPlayerPoolSize(); playerid != -1; playerid--) {
 	#endif
 		#if WC_CUSTOM_VENDING_MACHINES
@@ -4184,9 +4178,9 @@ static UpdateSyncData(playerid)
 		return;
 	}
 
-	#if WC_YSI_PACKAGE == true
+	#if defined _inc_y_iterate
 	foreach (new i : Player) {
-	#else
+	#else 
 	for (new i = GetPlayerPoolSize(); i != -1; i--) {
 	#endif
 		if (i != playerid && IsPlayerStreamedIn(playerid, i)) {
@@ -4303,9 +4297,9 @@ public WC_SpawnForStreamedIn(playerid)
 
 	SpawnPlayerForWorld(playerid);
 
-	#if WC_YSI_PACKAGE == true
+	#if defined _inc_y_iterate
 	foreach (new i : Player) {
-	#else
+	#else 
 	for (new i = GetPlayerPoolSize(); i != -1; i--) {
 	#endif
 		if (i != playerid && IsPlayerStreamedIn(playerid, i)) {
@@ -5215,9 +5209,9 @@ static DamageFeedUpdateText(playerid)
 
 static DamageFeedAddHitGiven(playerid, issuerid, Float:amount, weapon)
 {
-	#if WC_YSI_PACKAGE == true
+	#if defined _inc_y_iterate
 	foreach (new i : Player) {
-	#else
+	#else 
 	for (new i = GetPlayerPoolSize(); i != -1; i--) {
 	#endif
 		if (s_Spectating[i] == playerid && i != playerid) {
@@ -5230,9 +5224,9 @@ static DamageFeedAddHitGiven(playerid, issuerid, Float:amount, weapon)
 
 static DamageFeedAddHitTaken(playerid, issuerid, Float:amount, weapon)
 {
-	#if WC_YSI_PACKAGE == true
+	#if defined _inc_y_iterate
 	foreach (new i : Player) {
-	#else
+	#else 
 	for (new i = GetPlayerPoolSize(); i != -1; i--) {
 	#endif
 		if (s_Spectating[i] == playerid && i != playerid) {
@@ -5481,9 +5475,9 @@ public OnPlayerDamageDone(playerid, Float:amount, issuerid, weapon, bodypart)
 		if (s_DamageTakenSound) {
 			PlayerPlaySound(playerid, s_DamageTakenSound, 0.0, 0.0, 0.0);
 
-			#if WC_YSI_PACKAGE == true
+			#if defined _inc_y_iterate
 			foreach (new i : Player) {
-			#else
+			#else 
 			for (new i = GetPlayerPoolSize(); i != -1; i--) {
 			#endif
 				if (s_Spectating[i] == playerid && i != playerid) {
@@ -5495,9 +5489,9 @@ public OnPlayerDamageDone(playerid, Float:amount, issuerid, weapon, bodypart)
 		if (s_DamageGivenSound && issuerid != INVALID_PLAYER_ID) {
 			PlayerPlaySound(issuerid, s_DamageGivenSound, 0.0, 0.0, 0.0);
 
-			#if WC_YSI_PACKAGE == true
+			#if defined _inc_y_iterate
 			foreach (new i : Player) {
-			#else
+			#else 
 			for (new i = GetPlayerPoolSize(); i != -1; i--) {
 			#endif
 				if (s_Spectating[i] == issuerid && i != issuerid) {

--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -67,13 +67,13 @@
 		#error The SKY plugin is required, get it here: github.com/oscar-broman/sky
 	#endif
 #endif
-#if WC_YSI_PACKAGE == true
-	#if !defined _inc_y_iterate
-		#tryinclude <YSI_Data\y_iterate>
+#if !defined _inc_y_iterate
+	#if WC_YSI_PACKAGE == true
+	#tryinclude <YSI_Data\y_iterate>
 
-		#if !defined _inc_y_iterate
-			#error #error the YSI library is required, get it here: github.com/pawn-lang/YSI-Includes
-		#endif
+	#if !defined _inc_y_iterate
+		#error #error the YSI library is required, get it here: github.com/pawn-lang/YSI-Includes
+	#endif
 	#endif
 #endif
 // Pre-hooks for hooking callbacks

--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -50,6 +50,11 @@
 	#define WC_CUSTOM_VENDING_MACHINES true
 #endif
 
+// YSI Packages by default is turn on, if someone not use this package he can turn off it.
+#if !defined WC_YSI_PACKAGE
+	#define WC_YSI_PACKAGE true
+#endif
+
 #if WC_USE_STREAMER && !defined Streamer_IncludeFileVersion
 	#error streamer.inc is required when WC_USE_STREAMER=true
 #endif
@@ -62,15 +67,15 @@
 		#error The SKY plugin is required, get it here: github.com/oscar-broman/sky
 	#endif
 #endif
-
-#if !defined _inc_y_iterate
-	#tryinclude <YSI_Data\y_iterate>
-
+#if WC_YSI_PACKAGE == true
 	#if !defined _inc_y_iterate
-		#error #error the YSI library is required, get it here: github.com/pawn-lang/YSI-Includes
+		#tryinclude <YSI_Data\y_iterate>
+
+		#if !defined _inc_y_iterate
+			#error #error the YSI library is required, get it here: github.com/pawn-lang/YSI-Includes
+		#endif
 	#endif
 #endif
-
 // Pre-hooks for hooking callbacks
 #if !defined CHAIN_ORDER
 	#define CHAIN_ORDER() 0
@@ -1153,9 +1158,12 @@ stock SetCbugAllowed(bool:enabled, playerid = INVALID_PLAYER_ID)
 {
 	if (playerid == INVALID_PLAYER_ID) {
 		s_CbugGlobal = enabled;
-
-		foreach (new i : Player) {
-			s_CbugAllowed[i] = enabled;
+		#if WC_YSI_PACKAGE == true
+		foreach (new i : Player) {		
+		#else
+		for (new i = GetPlayerPoolSize(); i != -1; i--) {
+		#endif	
+		s_CbugAllowed[i] = enabled;	
 		}
 	} else {
 		s_CbugAllowed[playerid] = enabled;
@@ -1231,7 +1239,11 @@ stock SetDamageFeed(bool:toggle)
 {
 	s_DamageFeed = toggle;
 
+	#if WC_YSI_PACKAGE == true
 	foreach (new i : Player) {
+	#else
+	for (new i = GetPlayerPoolSize(); i != -1; i--) {		
+	#endif
 		DamageFeedUpdate(i);
 	}
 }
@@ -2296,16 +2308,18 @@ public OnPlayerDisconnect(playerid, reason)
 
 	for (new i = 0; i < sizeof(s_InternalPlayerTextDraw[]); i++) {
 		s_InternalPlayerTextDraw[playerid][PlayerText:i] = false;
-	}
-
+	}	
+	#if WC_YSI_PACKAGE == true
 	foreach (new i : Player) {
+	#else
+	for (new i = GetPlayerPoolSize(); i != -1; i--) {
+	#endif	
 		for (new j = 0; j < sizeof(s_PreviousHits[]); j++) {
 			if (s_PreviousHits[i][j][e_Issuer] == playerid) {
 				s_PreviousHits[i][j][e_Issuer] = INVALID_PLAYER_ID;
 			}
-		}
+		}	
 	}
-
 	return 1;
 }
 
@@ -2700,8 +2714,11 @@ public OnPlayerKeyStateChange(playerid, newkeys, oldkeys)
 				SetTimerEx("WC_CbugPunishment", 600, false, "ii", playerid, GetPlayerWeapon(playerid));
 
 				s_CbugFroze[playerid] = tick;
-
+				#if WC_YSI_PACKAGE == true	
 				foreach (new i : Player) {
+				#else
+				for (new i = GetPlayerPoolSize(); i != -1; i--) {
+				#endif	
 					for (new j = 0; j < sizeof(s_PreviousHits[]); j++) {
 						if (s_PreviousHits[i][j][e_Issuer] == playerid && tick - s_PreviousHits[i][j][e_Tick] <= 1200) {
 							s_PreviousHits[i][j][e_Issuer] = INVALID_PLAYER_ID;
@@ -2863,7 +2880,11 @@ public OnPlayerStateChange(playerid, newstate, oldstate)
 			GetPlayerVelocity(playerid, vx, vy, vz);
 
 			if (vx*vx + vy*vy + vz*vz <= 0.05) {
-				foreach (new i : Player) {
+					#if WC_YSI_PACKAGE == true
+					foreach (new i : Player) {
+					#else
+					for (new i = GetPlayerPoolSize(); i != -1; i--) {
+					#endif
 					if (i != playerid && IsPlayerStreamedIn(playerid, i)) {
 						SendLastSyncPacket(playerid, i);
 						ClearAnimationsForPlayer(playerid, i);
@@ -3631,7 +3652,11 @@ public OnPlayerWeaponShot(playerid, weaponid, hittype, hitid, Float:fX, Float:fY
 			new has_driver = false;
 			new has_passenger = false;
 
+			#if WC_YSI_PACKAGE == true
 			foreach (new otherid : Player) {
+			#else
+			for (new otherid = GetPlayerPoolSize(); otherid != -1; otherid--) {
+			#endif
 				if (otherid == playerid) {
 					continue;
 				}
@@ -3671,7 +3696,11 @@ public OnPlayerWeaponShot(playerid, weaponid, hittype, hitid, Float:fX, Float:fY
 		if (s_VehicleUnoccupiedDamage) {
 			new has_occupent = false;
 
+			#if WC_YSI_PACKAGE == true
 			foreach (new otherid : Player) {
+			#else
+			for (new otherid = GetPlayerPoolSize(); otherid != -1; otherid--) {
+			#endif
 				if (otherid == playerid) {
 					continue;
 				}
@@ -3842,7 +3871,11 @@ static ScriptInit()
 
 	new tick = GetTickCount();
 
+	#if WC_YSI_PACKAGE == true
 	foreach (new playerid : Player) {
+	#else
+	for (new playerid = GetPlayerPoolSize(); playerid != -1; playerid--) {
+	#endif
 		s_PlayerTeam[playerid] = GetPlayerTeam(playerid);
 
 		SetPlayerTeam(playerid, s_PlayerTeam[playerid]);
@@ -3904,7 +3937,11 @@ static ScriptExit()
 		DestroyVendingMachines();
 	#endif
 
+	#if WC_YSI_PACKAGE == true
 	foreach (new playerid : Player) {
+	#else
+	for (new playerid = GetPlayerPoolSize(); playerid != -1; playerid--) {
+	#endif
 		#if WC_CUSTOM_VENDING_MACHINES
 			if (s_VendingUseTimer[playerid] != -1) {
 				KillTimer(s_VendingUseTimer[playerid]);
@@ -4147,7 +4184,11 @@ static UpdateSyncData(playerid)
 		return;
 	}
 
+	#if WC_YSI_PACKAGE == true
 	foreach (new i : Player) {
+	#else
+	for (new i = GetPlayerPoolSize(); i != -1; i--) {
+	#endif
 		if (i != playerid && IsPlayerStreamedIn(playerid, i)) {
 			SendLastSyncPacket(playerid, i);
 		}
@@ -4262,7 +4303,11 @@ public WC_SpawnForStreamedIn(playerid)
 
 	SpawnPlayerForWorld(playerid);
 
+	#if WC_YSI_PACKAGE == true
 	foreach (new i : Player) {
+	#else
+	for (new i = GetPlayerPoolSize(); i != -1; i--) {
+	#endif
 		if (i != playerid && IsPlayerStreamedIn(playerid, i)) {
 			SendLastSyncPacket(playerid, i);
 			ClearAnimationsForPlayer(playerid, i);
@@ -5170,7 +5215,11 @@ static DamageFeedUpdateText(playerid)
 
 static DamageFeedAddHitGiven(playerid, issuerid, Float:amount, weapon)
 {
+	#if WC_YSI_PACKAGE == true
 	foreach (new i : Player) {
+	#else
+	for (new i = GetPlayerPoolSize(); i != -1; i--) {
+	#endif
 		if (s_Spectating[i] == playerid && i != playerid) {
 			DamageFeedAddHit(s_DamageFeedHitsGiven[i], i, issuerid, amount, weapon);
 		}
@@ -5181,7 +5230,11 @@ static DamageFeedAddHitGiven(playerid, issuerid, Float:amount, weapon)
 
 static DamageFeedAddHitTaken(playerid, issuerid, Float:amount, weapon)
 {
+	#if WC_YSI_PACKAGE == true
 	foreach (new i : Player) {
+	#else
+	for (new i = GetPlayerPoolSize(); i != -1; i--) {
+	#endif
 		if (s_Spectating[i] == playerid && i != playerid) {
 			DamageFeedAddHit(s_DamageFeedHitsTaken[i], i, issuerid, amount, weapon);
 		}
@@ -5428,7 +5481,11 @@ public OnPlayerDamageDone(playerid, Float:amount, issuerid, weapon, bodypart)
 		if (s_DamageTakenSound) {
 			PlayerPlaySound(playerid, s_DamageTakenSound, 0.0, 0.0, 0.0);
 
+			#if WC_YSI_PACKAGE == true
 			foreach (new i : Player) {
+			#else
+			for (new i = GetPlayerPoolSize(); i != -1; i--) {
+			#endif
 				if (s_Spectating[i] == playerid && i != playerid) {
 					PlayerPlaySound(i, s_DamageTakenSound, 0.0, 0.0, 0.0);
 				}
@@ -5438,7 +5495,11 @@ public OnPlayerDamageDone(playerid, Float:amount, issuerid, weapon, bodypart)
 		if (s_DamageGivenSound && issuerid != INVALID_PLAYER_ID) {
 			PlayerPlaySound(issuerid, s_DamageGivenSound, 0.0, 0.0, 0.0);
 
+			#if WC_YSI_PACKAGE == true
 			foreach (new i : Player) {
+			#else
+			for (new i = GetPlayerPoolSize(); i != -1; i--) {
+			#endif
 				if (s_Spectating[i] == issuerid && i != issuerid) {
 					PlayerPlaySound(i, s_DamageGivenSound, 0.0, 0.0, 0.0);
 				}


### PR DESCRIPTION
This is only for people who not using the YSI  packages, like me so i made this easy, the  scripters before including the Weapon Config can set with code:
#define WC_YSI_PACKAGE false, and disable Foreach iterate function and '#error the YSI library is required, get it here: github.com/pawn-lang/YSI-Includes' error.
The YSI Libary is by default set to enabled (true).
Y-Less i respect your work this is not personal, but someone don't want to include all package via 1 include. Thats it, thanks.