### PR TITLE
Minor corrections to the last PR

### DIFF
--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -3267,12 +3267,12 @@ public OnPlayerGiveDamage(playerid, damagedid, Float:amount, weaponid, bodypart)
 		if (valid) {
 			new Float:dist = GetPlayerDistanceFromPoint(damagedid, s_LastShot[playerid][e_HX], s_LastShot[playerid][e_HY], s_LastShot[playerid][e_HZ]);
 
-			if (dist > 15.0) {
+			if (dist > 20.0) {
 				new in_veh = IsPlayerInAnyVehicle(damagedid) || GetPlayerSurfingVehicleID(damagedid) != INVALID_VEHICLE_ID;
 
 				if ((!in_veh && GetPlayerSurfingObjectID(damagedid) == INVALID_OBJECT_ID) || dist > 50.0) {
 					valid = false;
-					AddRejectedHit(playerid, damagedid, HIT_TOO_FAR_FROM_ORIGIN, weaponid, _:dist);
+					AddRejectedHit(playerid, damagedid, HIT_TOO_FAR_FROM_SHOT, weaponid, _:dist);
 				}
 			}
 		}
@@ -3584,12 +3584,14 @@ public OnPlayerWeaponShot(playerid, weaponid, hittype, hitid, Float:fX, Float:fY
 			}
 
 			new Float:dist = GetPlayerDistanceFromPoint(hitid, fHitPosX, fHitPosY, fHitPosZ);
-			new in_veh = IsPlayerInAnyVehicle(hitid);
+			new in_veh = IsPlayerInAnyVehicle(hitid) || GetPlayerSurfingVehicleID(hitid) != INVALID_VEHICLE_ID;
 
-			if ((!in_veh && dist > 20.0) || dist > 50.0) {
-				AddRejectedHit(playerid, damagedid, HIT_TOO_FAR_FROM_SHOT, weaponid, _:dist);
+			if (dist > 20.0) {
+				if ((!in_veh && GetPlayerSurfingObjectID(hitid) == INVALID_OBJECT_ID) || dist > 50.0) {
+					AddRejectedHit(playerid, damagedid, HIT_TOO_FAR_FROM_SHOT, weaponid, _:dist);
 
-				return 0;
+					return 0;
+				}
 			}
 		}
 	}
@@ -4541,7 +4543,7 @@ static ProcessDamage(&playerid, &issuerid, &Float:amount, &weaponid, &bodypart, 
 		GetPlayerPos(issuerid, x, y, z);
 		dist = GetPlayerDistanceFromPoint(playerid, x, y, z);
 
-		if (dist > s_WeaponRange[weaponid] + 2.0) {
+		if (0 <= weaponid < sizeof(s_WeaponRange) && dist > s_WeaponRange[weaponid] + 2.0) {
 			AddRejectedHit(issuerid, playerid, HIT_TOO_FAR_FROM_ORIGIN, weaponid, _:dist, _:s_WeaponRange[weaponid]);
 			return WC_INVALID_DISTANCE;
 		}


### PR DESCRIPTION
Some additional corrections including:
1. Check weaponid in ProcessDamage for its validity to use as index in s_WeaponRange. 'melee' variable can be true even for > 46 (and thus >= sizeof s_WeaponRange) according to [this code](https://github.com/oscar-broman/samp-weapon-config/blob/4a5556499023c3538b3176aa54841e9ef238b306/weapon-config.inc#L4497-L4519).
2. Change 'HIT_TOO_FAR_FROM_ORIGIN' to 'HIT_TOO_FAR_FROM_SHOT' where it is appropriate and some minor fixes for these checks.