### PR TITLE
"s_DeathTimer[playerid] = -1;" seems to be missed

### DIFF
--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -2573,6 +2573,7 @@ public OnPlayerDeath(playerid, killerid, reason)
 
 	if (s_DeathTimer[playerid] != -1) {
 		KillTimer(s_DeathTimer[playerid]);
+		s_DeathTimer[playerid] = -1;
 	}
 
 	if (s_IsDying[playerid]) {


### PR DESCRIPTION
In every place where weapon-config interacts with `s_DeathTimer` and kills it, it also reset its variable. Everywhere, except one place.