### PR TITLE
Fixes, improvements, more damage checks

### DIFF
--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -2479,7 +2479,6 @@ public OnPlayerSpawn(playerid)
 	if (s_DeathSkip[playerid] == 2) {
 		DebugMessage(playerid, "Death skipped");
 		SetPlayerSpecialAction(playerid, SPECIAL_ACTION_NONE);
-		GivePlayerWeapon(playerid, 0, 1);
 		SetPlayerArmedWeapon(playerid, 0);
 		ClearAnimations(playerid);
 
@@ -2891,6 +2890,11 @@ public OnPlayerEnterVehicle(playerid, vehicleid, ispassenger)
 
 	s_LastVehicleEnterTime[playerid] = gettime();
 	s_LastVehicleTick[playerid] = GetTickCount();
+
+	if (s_IsDying[playerid]) {
+		TogglePlayerControllable(playerid, false);
+		ApplyAnimation(playerid, "PED", "KO_skid_back", 4.1, 0, 0, 0, 1, 0, 1);
+	}
 
 	return WC_OnPlayerEnterVehicle(playerid, vehicleid, ispassenger);
 }

--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -1862,6 +1862,15 @@ stock WC_IsPlayerInCheckpoint(playerid)
 	return IsPlayerInCheckpoint(playerid);
 }
 
+stock WC_IsPlayerInRaceCheckpoint(playerid)
+{
+	if (!WC_IsPlayerSpawned(playerid)) {
+		return 0;
+	}
+
+	return IsPlayerInRaceCheckpoint(playerid);
+}
+
 stock WC_SetPlayerSpecialAction(playerid, actionid)
 {
 	if (!WC_IsPlayerSpawned(playerid)) {
@@ -3864,6 +3873,25 @@ public OnPlayerLeaveCheckpoint(playerid)
 	return WC_OnPlayerLeaveCheckpoint(playerid);
 }
 
+public OnPlayerEnterRaceCheckpoint(playerid)
+{
+	if (!WC_IsPlayerSpawned(playerid)) {
+		return 1;
+	}
+
+	return WC_OnPlayerEnterRaceCheckpoint(playerid);
+}
+
+public OnPlayerLeaveRaceCheckpoint(playerid)
+{
+	// If they're dying, it will be called in PlayerDeath (when the death anim begins)
+	if (s_IsDying[playerid]) {
+		return 1;
+	}
+
+	return WC_OnPlayerLeaveRaceCheckpoint(playerid);
+}
+
 /*
  * Internal functions
  */
@@ -4983,6 +5011,10 @@ static PlayerDeath(playerid, animlib[32], animname[32], anim_lock = 0, respawn_t
 	if (IsPlayerInCheckpoint(playerid)) {
 		WC_OnPlayerLeaveCheckpoint(playerid);
 	}
+
+	if (IsPlayerInRaceCheckpoint(playerid)) {
+		WC_OnPlayerLeaveRaceCheckpoint(playerid);
+	}
 }
 
 public OnPlayerPrepareDeath(playerid, animlib[32], animname[32], &anim_lock, &respawn_time)
@@ -5796,6 +5828,24 @@ CHAIN_FORWARD:WC_OnPlayerEnterCheckpoint(playerid) = 1;
 CHAIN_FORWARD:WC_OnPlayerLeaveCheckpoint(playerid) = 1;
 
 
+#if defined _ALS_OnPlayerEnterRaceCP
+	#undef OnPlayerEnterRaceCheckpoint
+#else
+	#define _ALS_OnPlayerEnterRaceCP
+#endif
+#define OnPlayerEnterRaceCheckpoint(%0) CHAIN_PUBLIC:WC_OnPlayerEnterRaceCheckpoint(%0)
+CHAIN_FORWARD:WC_OnPlayerEnterRaceCheckpoint(playerid) = 1;
+
+
+#if defined _ALS_OnPlayerLeaveRaceCP
+	#undef OnPlayerLeaveRaceCheckpoint
+#else
+	#define _ALS_OnPlayerLeaveRaceCP
+#endif
+#define OnPlayerLeaveRaceCheckpoint(%0) CHAIN_PUBLIC:WC_OnPlayerLeaveRaceCheckpoint(%0)
+CHAIN_FORWARD:WC_OnPlayerLeaveRaceCheckpoint(playerid) = 1;
+
+
 #if defined _ALS_OnInvalidWeaponDamage
 	#undef OnInvalidWeaponDamage
 #else
@@ -6054,6 +6104,7 @@ CHAIN_FORWARD:WC_OnPlayerDeathFinished(playerid, bool:cancelable) = 1;
 #endif
 #define DestroyVehicle WC_DestroyVehicle
 
+
 #if defined _ALS_CreateVehicle
 	#undef CreateVehicle
 #else
@@ -6077,12 +6128,21 @@ CHAIN_FORWARD:WC_OnPlayerDeathFinished(playerid, bool:cancelable) = 1;
 #endif
 #define AddStaticVehicleEx WC_AddStaticVehicleEx
 
+
 #if defined _ALS_IsPlayerInCheckpoint
 	#undef IsPlayerInCheckpoint
 #else
 	#define _ALS_IsPlayerInCheckpoint
 #endif
 #define IsPlayerInCheckpoint WC_IsPlayerInCheckpoint
+
+
+#if defined _ALS_IsPlayerInRaceCheckpoint
+	#undef IsPlayerInRaceCheckpoint
+#else
+	#define _ALS_IsPlayerInCheckpoint
+#endif
+#define IsPlayerInRaceCheckpoint WC_IsPlayerInRaceCheckpoint
 
 
 #if defined _ALS_SetPlayerSpecialAction

--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -3300,7 +3300,7 @@ public OnPlayerGiveDamage(playerid, damagedid, Float:amount, weaponid, bodypart)
 			}
 		} else if (s_LastShot[playerid][e_Hits] > 0) {
 			// Sniper doesn't always send OnPlayerWeaponShot
-			if (s_LastShot[playerid][e_Hits] > 3 && weaponid != WEAPON_SNIPER) {
+			if (s_LastShot[playerid][e_Hits] >= 3 && weaponid != WEAPON_SNIPER) {
 				valid = false;
 				AddRejectedHit(playerid, damagedid, HIT_MULTIPLE_PLAYERS, weaponid, s_LastShot[playerid][e_Hits] + 1);
 			} else {

--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -6140,7 +6140,7 @@ CHAIN_FORWARD:WC_OnPlayerDeathFinished(playerid, bool:cancelable) = 1;
 #if defined _ALS_IsPlayerInRaceCheckpoint
 	#undef IsPlayerInRaceCheckpoint
 #else
-	#define _ALS_IsPlayerInCheckpoint
+	#define _ALS_IsPlayerInRaceCheckpoint
 #endif
 #define IsPlayerInRaceCheckpoint WC_IsPlayerInRaceCheckpoint
 

--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -3222,6 +3222,11 @@ public OnPlayerGiveDamage(playerid, damagedid, Float:amount, weaponid, bodypart)
 		return 0;
 	}
 
+	// Driver doesn't call this callback even if he damage someone
+	if (GetPlayerState(playerid) == PLAYER_STATE_DRIVER) {
+		return 0;
+	}
+
 	new Float:bullets, err;
 
 	if ((err = ProcessDamage(damagedid, playerid, amount, weaponid, bodypart, bullets))) {


### PR DESCRIPTION
1. Checks for entering/leaving race checkpoints if player isn't spawned
2. Block OnPlayerGiveDamage for vehicle drivers as there is no known cases when they call it themselves (any damage from driver e.g. carpark and so on are handled by OnPlayerTakeDamage from damaged player only)
3. Stricter limit on the damage hits per shot
4. Minor fixes and corrections