### PR TITLE
Fix for fire & explosion -related damage spoofing

### DIFF
--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -3498,6 +3498,16 @@ public OnPlayerTakeDamage(playerid, issuerid, Float:amount, weaponid, bodypart)
 				return 0;
 			}
 		}
+
+		// Such reasons can be called long after issuer death, but it shouldn't be a hole
+		if(weaponid == WEAPON_FLAMETHROWER
+		|| weaponid == WEAPON_EXPLOSION) {
+			// Both players should see eachother, if playerid claims to keep issuerid valid
+			if ((!IsPlayerStreamedIn(playerid, issuerid) && !WC_IsPlayerPaused(issuerid)) || !IsPlayerStreamedIn(issuerid, playerid)) {
+				// Probably fake or belated damage, so let's just reset issuerid
+				issuerid = INVALID_PLAYER_ID;
+			}
+		}
 	}
 
 	new Float:bullets = 0.0, err;


### PR DESCRIPTION
Short description of the problem:
1. All weapons that a player sends with valid issuerid in OnPlayerTakeDamage successfully being checked according to 's_ValidDamageTaken', if such damage reason cannot be valid in both Give/Take damage events, the script rejects it;
2. If the weaponid passed the first check (it is valid reason for both modes), we have [additional checks](https://github.com/oscar-broman/samp-weapon-config/blob/82af127a236faaa2a93a3e08fda12c61edd6a74b/weapon-config.inc#L3472-L3501) after that, manually checking all the conditions and find if something can be wrong with each damage reason;
3. After those checks has passed, we still didn't check WEAPON_FLAMETHROWER and WEAPON_EXPLOSION reasons (whether the damage is reported by a player who has not even logged in? / on the other end of the map? / other impossible conditions that we do not check at all?).

The cause of the fact I've ignored this damage reasons before and didn't add any validation for it, is that these reasons can be called by a victim long time after issuerid become dead (pretty easy to imagine when a player set fire to another and died himself, and the second continues to burn as long as possible). So, preventing such damage if there is a long dist between two players or has passed a long time after the death of issuerid means the damage would stop after your issuerid become dead or anything, even if you burn or see an grenade explosion just in front on the skin.

But the case still need to be restricted and validated anyhow, so I've decided to reset issuerid in case of failure of validation checks, like [it has done in OnPlayerDeath](https://github.com/oscar-broman/samp-weapon-config/blob/82af127a236faaa2a93a3e08fda12c61edd6a74b/weapon-config.inc#L2591-L2594).