### PR TITLE
Extending validation checks

### DIFF
--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -3508,14 +3508,11 @@ public OnPlayerTakeDamage(playerid, issuerid, Float:amount, weaponid, bodypart)
 			}
 		}
 
-		// Such reasons can be called long after issuer death, but it shouldn't be a hole
-		if(weaponid == WEAPON_FLAMETHROWER
-		|| weaponid == WEAPON_EXPLOSION) {
-			// Both players should see eachother, if playerid claims to keep issuerid valid
-			if ((!IsPlayerStreamedIn(playerid, issuerid) && !WC_IsPlayerPaused(issuerid)) || !IsPlayerStreamedIn(issuerid, playerid)) {
-				// Probably fake or belated damage, so let's just reset issuerid
-				issuerid = INVALID_PLAYER_ID;
-			}
+		// Will be applied on fire, explosion, vehicle and heliblades (carpark) damage
+		// Both players should see eachother, if playerid claims to keep issuerid valid
+		if ((!IsPlayerStreamedIn(playerid, issuerid) && !WC_IsPlayerPaused(issuerid)) || !IsPlayerStreamedIn(issuerid, playerid)) {
+			// Probably fake or belated damage, so let's just reset issuerid
+			issuerid = INVALID_PLAYER_ID;
 		}
 	}
 


### PR DESCRIPTION
This change will extend validation checks for both issuerid for damagedid to be streamed for each other, not only for fire and explosion damage type as it is now, but also for any vehicle damage (hits by vehicle, hits by heli blades and car parking on damagedid). It was made because [the only check](https://github.com/oscar-broman/samp-weapon-config/blob/9e029fe24d880b324ad2c99ae71364784f6e7d31/weapon-config.inc#L3506) for being a driver for issuerid still used by cheaters to spoof damage for all players who are driving vehicle at the moment.