### PR TITLE
Fix for Knife "exploit"

### DIFF
--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -3403,10 +3403,9 @@ public OnPlayerTakeDamage(playerid, issuerid, Float:amount, weaponid, bodypart)
 			DebugMessage(playerid, "climb bug prevented");
 			return 0;
 		}
-	}
+	} else if (weaponid == WEAPON_KNIFE) {
+		// Being knifed client-side
 
-	// Being knifed client-side
-	if (weaponid == WEAPON_KNIFE) {
 		// With the plugin, this part is never actually used (it can't happen)
 		if (_:amount == _:0.0) {
 			if (s_KnifeTimeout[playerid] != -1) {
@@ -4553,18 +4552,15 @@ static ProcessDamage(&playerid, &issuerid, &Float:amount, &weaponid, &bodypart, 
 	// Punching with a parachute
 	if (weaponid == WEAPON_PARACHUTE) {
 		weaponid = WEAPON_UNARMED;
-	}
+	} else if (weaponid == WEAPON_COLLISION) {
+		// Collision damage should never be above 165
 
-	// Collision damage should never be above 165
-	if (weaponid == WEAPON_COLLISION) {
 		if (amount > 165.0) {
 			amount = 1.0;
 		} else {
 			amount /= 165.0;
 		}
-	}
-
-	if (weaponid == WEAPON_EXPLOSION) {
+	} else if (weaponid == WEAPON_EXPLOSION) {
 		// Explosions do at most 82.5 damage. This will later be multipled by the damage value
 		amount /= 82.5;
 
@@ -4714,10 +4710,9 @@ static ProcessDamage(&playerid, &issuerid, &Float:amount, &weaponid, &bodypart, 
 				return WC_INVALID_DAMAGE;
 			}
 		}
-	}
+	} else if (weaponid == WEAPON_DEAGLE) {
+		// Check deagle damage
 
-	// Check deagle damage
-	if (weaponid == WEAPON_DEAGLE) {
 		switch (amount) {
 			case 46.200000762939453125,
 			     23.1000003814697265625: {}

--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -2735,7 +2735,7 @@ public WC_CbugPunishment(playerid, weapon) {
 	FreezeSyncPacket(playerid, .toggle = false);
 	SetPlayerArmedWeapon(playerid, weapon);
 	
-	if(!IsPlayerDying(playerid)) {
+	if (!IsPlayerDying(playerid)) {
 		ClearAnimations(playerid, 1);
 	}
 }
@@ -3175,6 +3175,21 @@ public OnPlayerGiveDamage(playerid, damagedid, Float:amount, weaponid, bodypart)
 				SetPlayerArmedWeapon(playerid, 0);
 
 				return 0;
+			} else {
+				new Float:x, Float:y, Float:z;
+				GetPlayerPos(playerid, x, y, z);
+
+				if (GetPlayerDistanceFromPoint(damagedid, x, y, z) > s_WeaponRange[weaponid] + 2.0) {
+					if (s_KnifeTimeout[damagedid] != -1) {
+						KillTimer(s_KnifeTimeout[damagedid]);
+					}
+
+					s_KnifeTimeout[damagedid] = SetTimerEx("WC_SpawnForStreamedIn", 150, false, "i", damagedid);
+					ClearAnimations(playerid, 1);
+					SetPlayerArmedWeapon(playerid, 0);
+
+					return 0;
+				}
 			}
 
 			if (!OnPlayerDamage(damagedid, amount, playerid, weaponid, bodypart)) {
@@ -3418,6 +3433,15 @@ public OnPlayerTakeDamage(playerid, issuerid, Float:amount, weaponid, bodypart)
 				ResyncPlayer(playerid);
 
 				return 0;
+			} else {
+				new Float:x, Float:y, Float:z;
+				GetPlayerPos(issuerid, x, y, z);
+
+				if (GetPlayerDistanceFromPoint(playerid, x, y, z) > s_WeaponRange[weaponid] + 2.0) {
+					ResyncPlayer(playerid);
+
+					return 0;
+				}
 			}
 
 			if (!OnPlayerDamage(playerid, amount, issuerid, weaponid, bodypart)) {
@@ -3494,15 +3518,15 @@ public OnPlayerTakeDamage(playerid, issuerid, Float:amount, weaponid, bodypart)
 		}
 
 		// https://github.com/oscar-broman/samp-weapon-config/issues/104
-		if(weaponid == WEAPON_COLLISION
+		if (weaponid == WEAPON_COLLISION
 		|| weaponid == WEAPON_DROWN) {
 			return 0;
 		}
 
 		// https://github.com/oscar-broman/samp-weapon-config/issues/104
-		if(weaponid == WEAPON_VEHICLE
+		if (weaponid == WEAPON_VEHICLE
 		|| weaponid == WEAPON_HELIBLADES) {
-			if(GetPlayerState(issuerid) != PLAYER_STATE_DRIVER) {
+			if (GetPlayerState(issuerid) != PLAYER_STATE_DRIVER) {
 				return 0;
 			}
 		}
@@ -3530,9 +3554,9 @@ public OnPlayerTakeDamage(playerid, issuerid, Float:amount, weaponid, bodypart)
 	}
 
 	if (IsBulletWeapon(weaponid)) {
-		new Float:x, Float:y, Float:z;
+		new Float:x, Float:y, Float:z, Float:dist;
 		GetPlayerPos(issuerid, x, y, z);
-		new Float:dist = GetPlayerDistanceFromPoint(playerid, x, y, z);
+		dist = GetPlayerDistanceFromPoint(playerid, x, y, z);
 
 		if (dist > s_WeaponRange[weaponid] + 2.0) {
 			AddRejectedHit(issuerid, playerid, HIT_OUT_OF_RANGE, weaponid, _:dist, _:s_WeaponRange[weaponid]);
@@ -4765,7 +4789,7 @@ static ProcessDamage(&playerid, &issuerid, &Float:amount, &weaponid, &bodypart, 
 		case DAMAGE_TYPE_RANGE,
 		     DAMAGE_TYPE_RANGE_MULTIPLIER: {
 			new Float:length = 0.0;
-			if(s_LagCompMode) {
+			if (s_LagCompMode) {
 				length = s_LastShot[issuerid][e_Length];
 			} else {
 				new Float:X, Float:Y, Float:Z;


### PR DESCRIPTION
This fixes issue #238, adding damage validation for distance in knife-specific check which is applied before ([and instead of](https://github.com/oscar-broman/samp-weapon-config/blob/f66218189700899cf64e56e94e8efe8190d95697/weapon-config.inc#L3233)) main [ProcessDamage](https://github.com/oscar-broman/samp-weapon-config/blob/f66218189700899cf64e56e94e8efe8190d95697/weapon-config.inc#L3250) function.

The reason I didn't move ProcessDamage and other validation checks above knife check (so it could validate knife cases too) is in that any knife damage was never considered to be checked in ProcessDamage function and there needs to be a lot of additional exceptions for knife in many places, like [here](https://github.com/oscar-broman/samp-weapon-config/blob/f66218189700899cf64e56e94e8efe8190d95697/weapon-config.inc#L4659-L4663) (where the function won't process any knife damage just because it doesn't consider it at all). Another cause to have this kind of fix with another duplication of `s_WeaponRange` check inside knife check instead of validation damage distance in ProcessDamage is in that we need to resync "knifed" player at least for issuerid (instead of just blocking the damage like ProcessDamage does), assuming that the distance exceeding may be not only due to deliberate spoofing, but also due to sync bugs.

P.s. Merged another PR while it was forked, so that you can see some extra commits (squash on merge if it doesn't look good).