### PR TITLE
Sniper bug improvement

### DIFF
--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -121,6 +121,7 @@ static stock _WC_IncludeStates() <_ALS : _ALS_go> {}
 enum {
 	WC_NO_ERROR,
 	WC_NO_ISSUER,
+	WC_SNIPER_BUG,
 	WC_NO_DAMAGED,
 	WC_INVALID_DAMAGE,
 	WC_INVALID_DISTANCE
@@ -3319,7 +3320,7 @@ public OnPlayerGiveDamage(playerid, damagedid, Float:amount, weaponid, bodypart)
 
 	new Float:bullets, err;
 
-	if ((err = ProcessDamage(damagedid, playerid, amount, weaponid, bodypart, bullets))) {
+	if ((err = ProcessDamage(damagedid, playerid, playerid, amount, weaponid, bodypart, bullets))) {
 		if (err == WC_INVALID_DAMAGE) {
 			AddRejectedHit(playerid, damagedid, HIT_INVALID_DAMAGE, weaponid, _:amount);
 		}
@@ -3563,6 +3564,8 @@ public OnPlayerTakeDamage(playerid, issuerid, Float:amount, weaponid, bodypart)
 		}
 	}
 
+	// Get the real issuerid before its potentially set to INVALID_PLAYER_ID, just for a proper sniper bug detection
+	new realissuerid = issuerid;
 	// Should still be damaged by grenades or fire after someone has died
 	if (issuerid != INVALID_PLAYER_ID && IsPlayerConnected(issuerid)) {
 		if (HasSameTeam(playerid, issuerid)) {
@@ -3602,7 +3605,7 @@ public OnPlayerTakeDamage(playerid, issuerid, Float:amount, weaponid, bodypart)
 
 	new Float:bullets = 0.0, err;
 
-	if ((err = ProcessDamage(playerid, issuerid, amount, weaponid, bodypart, bullets))) {
+	if ((err = ProcessDamage(playerid, issuerid, realissuerid, amount, weaponid, bodypart, bullets))) {
 		if (err == WC_INVALID_DAMAGE) {
 			AddRejectedHit(issuerid, playerid, HIT_INVALID_DAMAGE, weaponid, _:amount);
 		}
@@ -4703,7 +4706,7 @@ public WC_SetSpawnForStreamedIn(playerid)
 	s_SpawnForStreamedIn[playerid] = true;
 }
 
-static ProcessDamage(&playerid, &issuerid, &Float:amount, &weaponid, &bodypart, &Float:bullets)
+static ProcessDamage(&playerid, &issuerid, &realissuerid, &Float:amount, &weaponid, &bodypart, &Float:bullets)
 {
 	if (amount < 0.0) {
 		return WC_INVALID_DAMAGE;
@@ -4798,8 +4801,8 @@ static ProcessDamage(&playerid, &issuerid, &Float:amount, &weaponid, &bodypart, 
 	}
 
 	// Bullet or melee damage must have an issuerid, otherwise something has gone wrong (e.g. sniper bug)
-	if (issuerid == INVALID_PLAYER_ID && (IsBulletWeapon(weaponid) || IsMeleeWeapon(weaponid))) {
-		return WC_NO_ISSUER;
+	if (realissuerid == INVALID_PLAYER_ID && (IsBulletWeapon(weaponid) || IsMeleeWeapon(weaponid))) {
+		return WC_SNIPER_BUG;
 	}
 
 	// Punching with a parachute

--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -121,7 +121,6 @@ static stock _WC_IncludeStates() <_ALS : _ALS_go> {}
 enum {
 	WC_NO_ERROR,
 	WC_NO_ISSUER,
-	WC_SNIPER_BUG,
 	WC_NO_DAMAGED,
 	WC_INVALID_DAMAGE,
 	WC_INVALID_DISTANCE
@@ -3320,7 +3319,7 @@ public OnPlayerGiveDamage(playerid, damagedid, Float:amount, weaponid, bodypart)
 
 	new Float:bullets, err;
 
-	if ((err = ProcessDamage(damagedid, playerid, playerid, amount, weaponid, bodypart, bullets))) {
+	if ((err = ProcessDamage(damagedid, playerid, amount, weaponid, bodypart, bullets))) {
 		if (err == WC_INVALID_DAMAGE) {
 			AddRejectedHit(playerid, damagedid, HIT_INVALID_DAMAGE, weaponid, _:amount);
 		}
@@ -3564,8 +3563,6 @@ public OnPlayerTakeDamage(playerid, issuerid, Float:amount, weaponid, bodypart)
 		}
 	}
 
-	// Get the real issuerid before its potentially set to INVALID_PLAYER_ID, just for a proper sniper bug detection
-	new realissuerid = issuerid;
 	// Should still be damaged by grenades or fire after someone has died
 	if (issuerid != INVALID_PLAYER_ID && IsPlayerConnected(issuerid)) {
 		if (HasSameTeam(playerid, issuerid)) {
@@ -3598,14 +3595,14 @@ public OnPlayerTakeDamage(playerid, issuerid, Float:amount, weaponid, bodypart)
 		// Will be applied on fire, explosion, vehicle and heliblades (carpark) damage
 		// Both players should see eachother, if playerid claims to keep issuerid valid
 		if ((!IsPlayerStreamedIn(playerid, issuerid) && !WC_IsPlayerPaused(issuerid)) || !IsPlayerStreamedIn(issuerid, playerid)) {
-			// Probably fake or belated damage, so let's just reset issuerid
-			issuerid = INVALID_PLAYER_ID;
+			AddRejectedHit(playerid, damagedid, HIT_UNSTREAMED, weaponid, damagedid);
+			return 0;
 		}
 	}
 
 	new Float:bullets = 0.0, err;
 
-	if ((err = ProcessDamage(playerid, issuerid, realissuerid, amount, weaponid, bodypart, bullets))) {
+	if ((err = ProcessDamage(playerid, issuerid, amount, weaponid, bodypart, bullets))) {
 		if (err == WC_INVALID_DAMAGE) {
 			AddRejectedHit(issuerid, playerid, HIT_INVALID_DAMAGE, weaponid, _:amount);
 		}
@@ -4707,7 +4704,7 @@ public WC_SetSpawnForStreamedIn(playerid)
 	s_SpawnForStreamedIn[playerid] = true;
 }
 
-static ProcessDamage(&playerid, &issuerid, &realissuerid, &Float:amount, &weaponid, &bodypart, &Float:bullets)
+static ProcessDamage(&playerid, &issuerid, &Float:amount, &weaponid, &bodypart, &Float:bullets)
 {
 	if (amount < 0.0) {
 		return WC_INVALID_DAMAGE;
@@ -4802,8 +4799,8 @@ static ProcessDamage(&playerid, &issuerid, &realissuerid, &Float:amount, &weapon
 	}
 
 	// Bullet or melee damage must have an issuerid, otherwise something has gone wrong (e.g. sniper bug)
-	if (realissuerid == INVALID_PLAYER_ID && (IsBulletWeapon(weaponid) || IsMeleeWeapon(weaponid))) {
-		return WC_SNIPER_BUG;
+	if (issuerid == INVALID_PLAYER_ID && (IsBulletWeapon(weaponid) || IsMeleeWeapon(weaponid))) {
+		return WC_NO_ISSUER;
 	}
 
 	// Punching with a parachute

--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -4447,19 +4447,20 @@ static UpdateHealthBar(playerid, bool:force = false)
 					68.6,
 					"LD_SPAC:white"
 				);
-				PlayerTextDrawTextSize(playerid,
-					s_HealthBarForeground[playerid],
-					WC_Bar_Calculate(
-					57.6,
-					100.0,
-					float(health)),
-					5.0
-				);
 
 				if (s_HealthBarForeground[playerid] == PlayerText:INVALID_TEXT_DRAW) {
 					printf("(wc) WARN: Unable to create player healthbar foreground");
 				} else {
 					s_InternalPlayerTextDraw[playerid][s_HealthBarForeground[playerid]] = true;
+
+					PlayerTextDrawTextSize(playerid,
+						s_HealthBarForeground[playerid],
+						WC_Bar_Calculate(
+						57.6,
+						100.0,
+						float(health)),
+						5.0
+					);
 
 					PlayerTextDrawAlignment(playerid, 		s_HealthBarForeground[playerid], 1);
 					PlayerTextDrawColor(playerid, 			s_HealthBarForeground[playerid], WC_HEALTH_BAR_FG_COLOR);


### PR DESCRIPTION
When a player gets killed, and after the `respawn_time` passes, the player will briefly be streamed out and then streamed in to be respawned, and during that brief time if that player gets shot by any weapon, the library will set the `issuerid` to `INVALID_PLAYER_ID`, which later on will falsely trigger the sniper bug detection. This behavior can be quickly reproduced with `SetRespawnTime(0)` and respawning the player on the spot.

This PR is only relevant to servers with `lag_compensation` disabled.

This PR also added a new enum variant namely `WC_SNIPER_BUG` which can be used in `OnInvalidWeaponDamage`.