### PR TITLE
Many fixes and improvements

### DIFF
--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -2971,7 +2971,7 @@ public OnPlayerKeyStateChange(playerid, newkeys, oldkeys)
 public OnPlayerStreamIn(playerid, forplayerid)
 {
 	// Send ped floor_hit_f
-	if (s_IsDying[playerid]) {
+	if (s_IsDying[playerid] || s_InClassSelection[playerid]) {
 		SendLastSyncPacket(playerid, forplayerid, .animation = 0x2e040000 + 1150);
 	}
 

--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -3452,7 +3452,7 @@ public OnPlayerTakeDamage(playerid, issuerid, Float:amount, weaponid, bodypart)
 
 	UpdateHealthBar(playerid, true);
 
-	if (WC_IsPlayerSpawned(playerid)) {
+	if (!WC_IsPlayerSpawned(playerid)) {
 		return 0;
 	}
 

--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -1044,6 +1044,11 @@ stock WC_IsPlayerSpawned(playerid)
 	return false;
 }
 
+stock WC_IsPlayerPaused(playerid)
+{
+	return (GetTickCount() - s_LastUpdate[playerid] > 2000);
+}
+
 stock AverageShootRate(playerid, shots, &multiple_weapons = 0)
 {
 	if (playerid == INVALID_PLAYER_ID || s_ShotsFired[playerid] < shots) {
@@ -4400,11 +4405,6 @@ static HasSameTeam(playerid, otherid)
 	}
 
 	return (s_PlayerTeam[playerid] == s_PlayerTeam[otherid]);
-}
-
-stock WC_IsPlayerPaused(playerid)
-{
-	return (GetTickCount() - s_LastUpdate[playerid] > 2000);
 }
 
 static Float:WC_Bar_Calculate(Float:width, Float:max, Float:value)

--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -2630,7 +2630,6 @@ public OnPlayerRequestClass(playerid, classid)
 		s_IsDying[playerid] = false;
 	}
 
-	FreezeSyncPacket(playerid, .toggle = false);
 	UpdatePlayerVirtualWorld(playerid);
 
 	if (s_TrueDeath[playerid]) {

--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -2566,9 +2566,12 @@ public OnPlayerSpawn(playerid)
 	new animlib[32], animname[32];
 
 	if (s_DeathSkip[playerid] == 2) {
+		new w, a;
+		GetPlayerWeaponData(playerid, 0, w, a);
+
 		DebugMessage(playerid, "Death skipped");
 		SetPlayerSpecialAction(playerid, SPECIAL_ACTION_NONE);
-		SetPlayerArmedWeapon(playerid, 0);
+		SetPlayerArmedWeapon(playerid, w);
 		ClearAnimations(playerid);
 
 		animlib = "PED", animname = "IDLE_stance";
@@ -2788,6 +2791,9 @@ public OnPlayerDeath(playerid, killerid, reason)
 			}
 
 			s_DeathSkip[playerid] = 2;
+			
+			new w, a;
+			GetPlayerWeaponData(playerid, 0, w, a);
 
 			ForceClassSelection(playerid);
 			SetSpawnInfo(playerid, s_PlayerTeam[playerid], GetPlayerSkin(playerid), x, y, z, r, 0, 0, 0, 0, 0, 0);
@@ -2795,7 +2801,7 @@ public OnPlayerDeath(playerid, killerid, reason)
 			TogglePlayerSpectating(playerid, false);
 			SetSpawnInfo(playerid, s_PlayerTeam[playerid], GetPlayerSkin(playerid), x, y, z, r, 0, 0, 0, 0, 0, 0);
 			TogglePlayerControllable(playerid, true);
-			SetPlayerArmedWeapon(playerid, 0);
+			SetPlayerArmedWeapon(playerid, w);
 		} else {
 			SpawnPlayerInPlace(playerid);
 		}
@@ -3242,6 +3248,9 @@ public OnPlayerGiveDamage(playerid, damagedid, Float:amount, weaponid, bodypart)
 
 	if (weaponid == WEAPON_KNIFE) {
 		if (_:amount == _:0.0) {
+			new w, a;
+			GetPlayerWeaponData(playerid, 0, w, a);
+
 			// Resync without bothering the player being knifed
 			if (npc || HasSameTeam(playerid, damagedid)) {
 				if (s_KnifeTimeout[damagedid] != -1) {
@@ -3250,7 +3259,7 @@ public OnPlayerGiveDamage(playerid, damagedid, Float:amount, weaponid, bodypart)
 
 				s_KnifeTimeout[damagedid] = SetTimerEx("WC_SpawnForStreamedIn", 150, false, "i", damagedid);
 				ClearAnimations(playerid, 1);
-				SetPlayerArmedWeapon(playerid, 0);
+				SetPlayerArmedWeapon(playerid, w);
 
 				return 0;
 			} else {
@@ -3264,7 +3273,7 @@ public OnPlayerGiveDamage(playerid, damagedid, Float:amount, weaponid, bodypart)
 
 					s_KnifeTimeout[damagedid] = SetTimerEx("WC_SpawnForStreamedIn", 150, false, "i", damagedid);
 					ClearAnimations(playerid, 1);
-					SetPlayerArmedWeapon(playerid, 0);
+					SetPlayerArmedWeapon(playerid, w);
 
 					return 0;
 				}
@@ -3277,7 +3286,7 @@ public OnPlayerGiveDamage(playerid, damagedid, Float:amount, weaponid, bodypart)
 
 				s_KnifeTimeout[damagedid] = SetTimerEx("WC_SpawnForStreamedIn", 150, false, "i", damagedid);
 				ClearAnimations(playerid, 1);
-				SetPlayerArmedWeapon(playerid, 0);
+				SetPlayerArmedWeapon(playerid, w);
 
 				return 0;
 			}
@@ -3299,10 +3308,10 @@ public OnPlayerGiveDamage(playerid, damagedid, Float:amount, weaponid, bodypart)
 			DebugMessage(damagedid, "being knifed by %d", playerid);
 			DebugMessage(playerid, "knifing %d", damagedid);
 
-			new Float:a;
+			new Float:angle;
 
-			GetPlayerFacingAngle(damagedid, a);
-			SetPlayerFacingAngle(playerid, a);
+			GetPlayerFacingAngle(damagedid, angle);
+			SetPlayerFacingAngle(playerid, angle);
 
 			SetPlayerVelocity(damagedid, 0.0, 0.0, 0.0);
 			SetPlayerVelocity(playerid, 0.0, 0.0, 0.0);

--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -2463,7 +2463,6 @@ public OnPlayerSpawn(playerid)
 		DebugMessage(playerid, "Being forced into class selection");
 		ForceClassSelection(playerid);
 		SetPlayerHealth(playerid, 0.0);
-		SetPlayerVirtualWorld(playerid, WC_DEATH_WORLD);
 
 		return 1;
 	}
@@ -2630,8 +2629,6 @@ public OnPlayerRequestClass(playerid, classid)
 		s_IsDying[playerid] = false;
 	}
 
-	UpdatePlayerVirtualWorld(playerid);
-
 	if (s_TrueDeath[playerid]) {
 		if (!s_InClassSelection[playerid]) {
 			DebugMessage(playerid, "True death class selection");
@@ -2645,6 +2642,8 @@ public OnPlayerRequestClass(playerid, classid)
 			s_InClassSelection[playerid] = true;
 		}
 
+		UpdatePlayerVirtualWorld(playerid);
+
 		if (WC_OnPlayerRequestClass(playerid, classid)) {
 			s_PlayerClass[playerid] = classid;
 
@@ -2657,6 +2656,7 @@ public OnPlayerRequestClass(playerid, classid)
 
 		s_ForceClassSelection[playerid] = true;
 
+		SetPlayerVirtualWorld(playerid, WC_DEATH_WORLD);
 		SpawnPlayerInPlace(playerid);
 
 		return 0;
@@ -3071,6 +3071,10 @@ public OnPlayerUpdate(playerid)
 {
 	if (s_IsDying[playerid]) {
 		return 1;
+	}
+
+	if (s_ForceClassSelection[playerid]) {
+		return 0;
 	}
 
 	new tick = GetTickCount();

--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -4673,7 +4673,7 @@ public WC_DeathSkipEnd(playerid)
 	}
 
 	SetPlayerArmedWeapon(playerid, s_SyncData[playerid][e_Weapon]);
-	SetPlayerSpecialAction(playerid, 0);
+	SetPlayerSpecialAction(playerid, SPECIAL_ACTION_NONE);
 }
 
 forward WC_SpawnForStreamedIn(playerid);

--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -5254,7 +5254,7 @@ static PlayerDeath(playerid, animlib[32], animname[32], anim_lock = 0, respawn_t
 
 	new action = GetPlayerSpecialAction(playerid);
 
-	if (action && action != SPECIAL_ACTION_DUCK) {
+	if (action != SPECIAL_ACTION_NONE && action != SPECIAL_ACTION_DUCK) {
 		if (action == SPECIAL_ACTION_USEJETPACK) {
 			ClearAnimations(playerid);
 		}
@@ -5830,7 +5830,7 @@ static FreezeSyncPacket(playerid, bool:toggle)
 	s_LastSyncData[playerid][PR_keys] = 0;
 	s_LastSyncData[playerid][PR_udKey] = 0;
 	s_LastSyncData[playerid][PR_lrKey] = 0;
-	s_LastSyncData[playerid][PR_specialAction] = 0;
+	s_LastSyncData[playerid][PR_specialAction] = SPECIAL_ACTION_NONE;
 	s_LastSyncData[playerid][PR_velocity][0] = 0.0;
 	s_LastSyncData[playerid][PR_velocity][1] = 0.0;
 	s_LastSyncData[playerid][PR_velocity][2] = 0.0;

--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -1030,6 +1030,10 @@ stock WC_IsPlayerSpawned(playerid)
 		return false;
 	}
 
+	if (s_InClassSelection[playerid] || s_ForceClassSelection[playerid]) {
+		return false;
+	}
+
 	switch (GetPlayerState(playerid)) {
 		case PLAYER_STATE_ONFOOT .. PLAYER_STATE_PASSENGER,
 		     PLAYER_STATE_SPAWNED: {
@@ -3448,15 +3452,7 @@ public OnPlayerTakeDamage(playerid, issuerid, Float:amount, weaponid, bodypart)
 
 	UpdateHealthBar(playerid, true);
 
-	if (s_IsDying[playerid]) {
-		return 0;
-	}
-
-	if (s_BeingResynced[playerid]) {
-		return 0;
-	}
-
-	if (s_InClassSelection[playerid] || s_ForceClassSelection[playerid]) {
+	if (WC_IsPlayerSpawned(playerid)) {
 		return 0;
 	}
 

--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -2813,7 +2813,7 @@ public WC_CbugPunishment(playerid, weapon) {
 	FreezeSyncPacket(playerid, .toggle = false);
 	SetPlayerArmedWeapon(playerid, weapon);
 
-	if (!IsPlayerDying(playerid)) {
+	if (!s_IsDying[playerid]) {
 		ClearAnimations(playerid, 1);
 	}
 }
@@ -2822,7 +2822,7 @@ public OnPlayerKeyStateChange(playerid, newkeys, oldkeys)
 {
 	new animlib[32], animname[32];
 
-	if (!s_CbugAllowed[playerid] && !IsPlayerDying(playerid) && GetPlayerState(playerid) == PLAYER_STATE_ONFOOT) {
+	if (!s_CbugAllowed[playerid] && !s_IsDying[playerid] && GetPlayerState(playerid) == PLAYER_STATE_ONFOOT) {
 		if (newkeys & KEY_CROUCH) {
 			new tick = GetTickCount();
 			new diff = tick - s_LastShot[playerid][e_Tick];
@@ -6013,8 +6013,8 @@ public OnPlayerDamageDone(playerid, Float:amount, issuerid, weapon, bodypart)
 	s_PreviousHits[playerid][idx][e_Weapon] = weapon;
 	s_PreviousHits[playerid][idx][e_Amount] = amount;
 	s_PreviousHits[playerid][idx][e_Bodypart] = bodypart;
-	s_PreviousHits[playerid][idx][e_Health] = GetLastDamageHealth(playerid);
-	s_PreviousHits[playerid][idx][e_Armour] = GetLastDamageArmour(playerid);
+	s_PreviousHits[playerid][idx][e_Health] = s_DamageDoneHealth[playerid];
+	s_PreviousHits[playerid][idx][e_Armour] = s_DamageDoneArmour[playerid];
 
 	if (!IsHighRateWeapon(weapon)) {
 		DebugMessageAll("OnPlayerDamageDone(%d did %f to %d with %d on bodypart %d)", issuerid, amount, playerid, weapon, bodypart);

--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -2791,7 +2791,7 @@ public OnPlayerDeath(playerid, killerid, reason)
 			TogglePlayerSpectating(playerid, false);
 			SetSpawnInfo(playerid, s_PlayerTeam[playerid], GetPlayerSkin(playerid), x, y, z, r, 0, 0, 0, 0, 0, 0);
 			TogglePlayerControllable(playerid, true);
-			GivePlayerWeapon(playerid, 1, 1);
+			SetPlayerArmedWeapon(playerid, 0);
 		} else {
 			SpawnPlayerInPlace(playerid);
 		}

--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -62,12 +62,12 @@
 
 // Healthbar foreground color
 #if !defined WC_HEALTH_BAR_FG_COLOR
-	#define WC_HEALTH_BAR_FG_COLOR 0xB4191DFF //red
+	#define WC_HEALTH_BAR_FG_COLOR 0xB4191DFF // red
 #endif
 
 // Healthbar background color
 #if !defined WC_HEALTH_BAR_BG_COLOR
-	#define WC_HEALTH_BAR_BG_COLOR 0x5A0C0EFF //dark red
+	#define WC_HEALTH_BAR_BG_COLOR 0x5A0C0EFF // dark red
 #endif
 
 #if WC_USE_STREAMER && !defined Streamer_IncludeFileVersion
@@ -1171,8 +1171,8 @@ stock SetWeaponDamage(weaponid, damage_type, Float:amount, Float:...)
 
 		for (new i = 0; i < steps; i++) {
 			if (i) {
-				s_DamageRangeRanges[weaponid][i] = Float:getarg(1 + i*2);
-				s_DamageRangeValues[weaponid][i] = Float:getarg(2 + i*2);
+				s_DamageRangeRanges[weaponid][i] = Float:getarg(1 + i * 2);
+				s_DamageRangeValues[weaponid][i] = Float:getarg(2 + i * 2);
 			} else {
 				s_DamageRangeValues[weaponid][i] = amount;
 			}
@@ -2317,7 +2317,7 @@ public OnPlayerConnect(playerid)
 	s_DeathTimer[playerid] = -1;
 	s_DelayedDeathTimer[playerid] = -1;
 	s_DamageFeedPlayer[playerid] = -1;
-	s_EnableHealthBar[playerid] = true; //enable by default
+	s_EnableHealthBar[playerid] = true; // enable by default
 
 	#if !defined _INC_SKY
 		s_FakeHealth{playerid} = 255;
@@ -2808,7 +2808,7 @@ forward WC_CbugPunishment(playerid, weapon);
 public WC_CbugPunishment(playerid, weapon) {
 	FreezeSyncPacket(playerid, .toggle = false);
 	SetPlayerArmedWeapon(playerid, weapon);
-	
+
 	if (!IsPlayerDying(playerid)) {
 		ClearAnimations(playerid, 1);
 	}
@@ -3899,7 +3899,7 @@ public OnPlayerWeaponShot(playerid, weaponid, hittype, hitid, Float:fX, Float:fY
 				new Float:health;
 
 				GetVehicleHealth(hitid, health);
-				if (health >= 250.0) { //vehicles start on fire below 250 hp
+				if (health >= 250.0) { // vehicles start on fire below 250 hp
 					if (WEAPON_SHOTGUN <= weaponid <= WEAPON_SHOTGSPA) {
 						health -= 120.0;
 					} else {
@@ -5931,7 +5931,7 @@ static SendLastSyncPacket(playerid, toplayerid, animation = 0)
 		s_LastSyncData[playerid][PR_animationFlags] = 0;
 	}
 
-	BS_WriteOnFootSync(bs, s_LastSyncData[playerid], true); 
+	BS_WriteOnFootSync(bs, s_LastSyncData[playerid], true);
 	PR_SendPacket(bs, toplayerid, _, PR_RELIABLE_SEQUENCED);
 	BS_Delete(bs);
 


### PR DESCRIPTION
- Fixed bypass when cheaters could send a death + requestclass (noping at the same time any attempts to be spawned by the server) and become technically still dead but no more desynced (FreezeSyncPacket was disabled and they might start sending onfoot or other updates)
- Minor fixes for magic numbers in special action IDs
- Accessing internal variables directly instead of external API functions in a couple of places (those getters which were just returning a variable value but also have validation checks which anyway will always be passed and thus have little sense using them inside the lib itself)
- Fully fixed #238
- Force switching weapon to slot 0 done properly in every place
- WC_IsPlayerPaused moved to the right section
- Other minor fixes and corrections

Btw, these issues probably aren't relevant for now and can be closed:
#165, #183, #201 (was fixed in #207)