### PR TITLE
Prevent abusing death/resync from knife damage

### DIFF
--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -3219,6 +3219,10 @@ public OnPlayerGiveDamage(playerid, damagedid, Float:amount, weaponid, bodypart)
 		new npc = IsPlayerNPC(damagedid);
 
 		if (weaponid == WEAPON_KNIFE && _:amount == _:0.0) {
+			if (damagedid == playerid) {
+				return 0;
+			}
+
 			if (s_KnifeTimeout[damagedid] != -1) {
 				KillTimer(s_KnifeTimeout[damagedid]);
 			}
@@ -3265,6 +3269,10 @@ public OnPlayerGiveDamage(playerid, damagedid, Float:amount, weaponid, bodypart)
 		if (_:amount == _:0.0) {
 			new w, a;
 			GetPlayerWeaponData(playerid, 0, w, a);
+
+			if (damagedid == playerid) {
+				return 0;
+			}
 
 			// Resync without bothering the player being knifed
 			if (npc || HasSameTeam(playerid, damagedid)) {
@@ -3516,6 +3524,10 @@ public OnPlayerTakeDamage(playerid, issuerid, Float:amount, weaponid, bodypart)
 
 		// With the plugin, this part is never actually used (it can't happen)
 		if (_:amount == _:0.0) {
+			if (issuerid == playerid) {
+				return 0;
+			}
+
 			if (s_KnifeTimeout[playerid] != -1) {
 				KillTimer(s_KnifeTimeout[playerid]);
 


### PR DESCRIPTION
These checks prevent attempting to call server death by knifing yourself or attempting to abuse resync on yourself. Such checks are not relevant for any other damage reasons because of stream checks which used there ([1](https://github.com/oscar-broman/samp-weapon-config/blob/master/weapon-config.inc#L3355), [2](https://github.com/oscar-broman/samp-weapon-config/blob/master/weapon-config.inc#L3628)) and thus returned false if playerid and damagedid/issuerid was passed the same, but not in knife case as it processes first and only checks the distance between two players (and they have passed if two players are actually the same). Now it also consider an obviously spoofed data when the player sends issuerid or damagedid equal to his ID.

Cases of fake sending OnPlayerTakeDamage with INVALID_PLAYER_ID as issuerid are still a thing (as this could be called without any cheats, judging by [the initial checks for it in the script](https://github.com/oscar-broman/samp-weapon-config/blob/master/weapon-config.inc#L3525) which existed for years). Anyway, this won't lead to fake calling serverside death, but only resync will be applied in this case.