### PR TITLE
Fix for #242

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,8 @@ Same as above, but for hits inflicted with `OnPlayerGiveDamage`
 ```pawn
 DamagePlayer(playerid, Float:amount, issuerid = INVALID_PLAYER_ID, weaponid = WEAPON_UNKNOWN, bodypart = BODY_PART_UNKNOWN, bool:ignore_armour = false);
 ```
-Inflict a hit on a player. All callbacks except `OnPlayerWeaponShot` will be called.
+Inflict a hit on a player. All callbacks except `OnPlayerWeaponShot` will be called.  
+**Note:** do not use it inside OnPlayerDamage as you can just modify `amount` there
 * `ignore_armour` - When `true` will do damage straight to health, and not armour.
 
 ```pawn


### PR DESCRIPTION
This adds a readme note about using `DamagePlayer` inside `OnPlayerDamage` callback.
Fixes #242 