### PR TITLE
Weapon ranges adjusted for all possible platforms

### DIFF
--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -619,22 +619,22 @@ static s_DamageType[] = {
 // Note that due to various bugs, these can be exceeded, but
 // this include blocks out-of-range values.
 static Float:s_WeaponRange[] = {
-	1.6, // 0 - Fist
-	1.6, // 1 - Brass knuckles
-	1.6, // 2 - Golf club
-	1.6, // 3 - Nitestick
-	1.6, // 4 - Knife
-	1.6, // 5 - Bat
+	1.76, // 0 - Fist
+	1.76, // 1 - Brass knuckles
+	1.76, // 2 - Golf club
+	1.76, // 3 - Nitestick
+	1.76, // 4 - Knife
+	1.76, // 5 - Bat
 	1.6, // 6 - Shovel
-	1.6, // 7 - Pool cue
-	1.6, // 8 - Katana
-	1.6, // 9 - Chainsaw
-	1.6, // 10 - Dildo
-	1.6, // 11 - Dildo 2
-	1.6, // 12 - Vibrator
-	1.6, // 13 - Vibrator 2
-	1.6, // 14 - Flowers
-	1.6, // 15 - Cane
+	1.76, // 7 - Pool cue
+	1.76, // 8 - Katana
+	1.76, // 9 - Chainsaw
+	1.76, // 10 - Dildo
+	1.76, // 11 - Dildo 2
+	1.76, // 12 - Vibrator
+	1.76, // 13 - Vibrator 2
+	1.76, // 14 - Flowers
+	1.76, // 15 - Cane
 	40.0, // 16 - Grenade
 	40.0, // 17 - Teargas
 	40.0, // 18 - Molotov
@@ -665,7 +665,7 @@ static Float:s_WeaponRange[] = {
 	100.0, // 43 - Camera
 	100.0, // 44 - Night vision
 	100.0, // 45 - Infrared
-	1.6  // 46 - Parachute
+	1.76  // 46 - Parachute
 };
 
 // The fastest possible gap between weapon shots in milliseconds


### PR DESCRIPTION
Weapon ranges was adjusted for all possible (playable for now) platforms where SA-MP client can run. Namely, the changes related to the melee weapons whose ranges were slightly raised in all mobile game versions (I checked weapon.dat file from [UWP 1.0.0.9](https://www.microsoft.com/en-us/p/grand-theft-auto-san-andreas/9wzdncrfj1zn), [Android 2.10](https://play.google.com/store/apps/details?id=com.rockstargames.gtasa) and [iOS 2.2](https://apps.apple.com/us/app/grand-theft-auto-san-andreas/id763692274) versions, all of them are fully the same between each other and can be checked out [here](https://pastebin.com/1N6uwWcF)). The only difference of Android game with PC OG game in weapon.dat is melee weapons ranges and some other minor stuff at the end of the file (which doesn't affect any of the defined list in weapon-config, so, the last not so important).