### PR TITLE
Goggles effect check improvements

### DIFF
--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -1049,7 +1049,9 @@ static s_PlayerClass[MAX_PLAYERS] = {-2, ...};
 static bool:s_SpawnInfoModified[MAX_PLAYERS];
 static bool:s_AlreadyConnected[MAX_PLAYERS];
 static s_DeathSkip[MAX_PLAYERS];
+static s_GogglesUsed[MAX_PLAYERS];
 static s_DeathSkipTick[MAX_PLAYERS];
+static s_GogglesTick[MAX_PLAYERS];
 static s_LastDeathTick[MAX_PLAYERS];
 static s_LastVehicleTick[MAX_PLAYERS];
 static s_PreviousHits[MAX_PLAYERS][10][E_HIT_INFO];
@@ -2872,6 +2874,7 @@ public OnPlayerConnect(playerid)
 	s_SpawnInfoModified[playerid] = false;
 	s_PlayerFallbackSpawnInfo[playerid][e_Skin] = -1;
 	s_DeathSkip[playerid] = 0;
+	s_GogglesUsed[playerid] = 0;
 	s_LastVehicleTick[playerid] = 0;
 	s_PreviousHitI[playerid] = 0;
 	s_CbugAllowed[playerid] = s_CbugGlobal;
@@ -4740,13 +4743,26 @@ IPacket:WC_PLAYER_SYNC(playerid, BitStream:bs)
 	}
 
 	if (onFootData[PR_weaponId] == _:WEAPON_KNIFE && !s_KnifeSync) {
+		// Remove aim key
 		onFootData[PR_keys] &= ~_:KEY_HANDBRAKE;
-	}
-	#if !defined _INC_open_mp
-		else if (44 <= onFootData[PR_weaponId] <= 45) {
+	} else if (44 <= onFootData[PR_weaponId] <= 45) {
+		// Remove fire key
+		onFootData[PR_keys] &= ~KEY_FIRE;
+
+		// Keep preventing for some more packets
+		s_GogglesTick[playerid] = GetTickCount();
+		s_GogglesUsed[playerid] = 1;
+	} else if (s_GogglesUsed[playerid]) {
+		if (s_GogglesUsed[playerid] == 2 && GetTickCount() - s_GogglesTick[playerid] > 40) {
+			s_GogglesUsed[playerid] = 0;
+		} else {
+			// Remove fire key
 			onFootData[PR_keys] &= ~KEY_FIRE;
+
+			s_GogglesTick[playerid] = GetTickCount();
+			s_GogglesUsed[playerid] = 2;
 		}
-	#endif
+	}
 
 	BS_SetWriteOffset(bs, 8);
 	BS_WriteOnFootSync(bs, onFootData); // rewrite


### PR DESCRIPTION
Alright, I did some improvements to this check again, but this time it's a real found exploit which was reported a few weeks ago and I couldn't figure out what was the way of reproducing this all those days, trying out different theories.

The issue which fixed in this PR is:
1. A cheater can send the first packet with the desired weapons (44/45)
2. The second packet can be without any holding weapon, but with KEY_FIRE pressed
3. The game of the other players for some reason interpret it as a still-working way to enable goggles effect (and funny enough, but only goggles are subject to this)

The current implementation also considers any cases when the cheater is sending a bunch of packets to bypass server checks making some "valid gap" between two packets that is checked, like:
> \> Send onfoot with weapon 44  
> \> Send the same onfoot but both without weapon 44 and key pressed, doing it all together with the first packet, so the server could possibly send only the first for others (as it has some buffer of packets before sending)  
> \> Send key press without the weapon after some short time

This was well tested and finally solves the found issue.