### PR TITLE
Check if vehicle is streamed in

### DIFF
--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -4471,6 +4471,11 @@ public OnPlayerWeaponShot(playerid, WEAPON:weaponid, BULLET_HIT_TYPE:hittype, hi
 			return 0;
 		}
 
+		if (!IsVehicleStreamedIn(hitid, playerid)) {
+			AddRejectedHit(playerid, damagedid, HIT_UNSTREAMED, weaponid, hitid);
+			return 0;
+		}
+
 		new vehicleid = GetPlayerVehicleID(playerid);
 
 		// Shouldn't be possible to damage the vehicle you're in


### PR DESCRIPTION
Add a condition to check if the vehicle which player shoots at is inside his stream zone.
This prevents possible hacks with damaging cars without driver around the map if this option is enabled.