### PR TITLE
Remove `>= 0.0` for stealth knife damage

### DIFF
--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -3858,7 +3858,7 @@ public OnPlayerGiveDamage(playerid, damagedid, Float:amount, WEAPON:weaponid, bo
 	}
 
 	if (weaponid == WEAPON_KNIFE) {
-		if (_:amount >= _:0.0) {
+		if (_:amount == _:0.0) {
 			new WEAPON:w, a;
 			GetPlayerWeaponData(playerid, WEAPON_SLOT:0, w, a);
 
@@ -3943,7 +3943,7 @@ public OnPlayerGiveDamage(playerid, damagedid, Float:amount, WEAPON:weaponid, bo
 			ApplyAnimation(playerid, animlib, animname, 4.1, false, true, true, false, 1800, FORCE_SYNC:forcesync);
 
 			return 0;
-		} else {}
+		}
 	}
 
 	if (HasSameTeam(playerid, damagedid)) {


### PR DESCRIPTION
Currently this case (before the last change):
https://github.com/oscar-broman/samp-weapon-config/blob/c5f988bc19cb22d4e317e9e91090e1349a673da0/weapon-config.inc#L3861
is about processing stealth knife damage only, while anything with damage > 0.0 for knife is processed like any other melee weapon damage, inside `ProcessDamage` function.

So, as it turns out, both cases (when knife damage is 0.0 and when it's more than 0.0) are considered and validated by distance, just in different places. Keeping the change from commit `057e970`:
```pawn
if (_:amount >= _:0.0) {
```
it starts process any knife damage as stealth knife case.

Sorry for late investigation since my initial assumptions was different before all these tests.
Any allegedly working knife damagers should be firstly confirmed they are indeed cases with the latest version of weapon-config, since the previously commited change aims to solve a reported case without the details about what was used from server side.