### PR TITLE
redefinition of constant/macro

### DIFF
--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -395,7 +395,10 @@ forward OnRejectedHit(playerid, hit[E_REJECTED_HIT]);
 #define WEAPON_HELIBLADES (WEAPON:50)
 #define WEAPON_EXPLOSION (WEAPON:51)
 #define WEAPON_CARPARK (WEAPON:52)
-#define WEAPON_UNKNOWN (WEAPON:55)
+
+#if !defined WEAPON_UNKNOWN
+	#define WEAPON_UNKNOWN (WEAPON:55)
+#endif
 
 #if !defined _INC_SKY
 	// Define packet IDs


### PR DESCRIPTION
When using the include on open.mp, it causes a warning `redefinition of constant/macro (symbol "WEAPON_UNKNOWN")`