### PR TITLE
Redefine `WEAPON_UNKNOWN` if it's already defined

### DIFF
--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -395,7 +395,11 @@ forward OnRejectedHit(playerid, hit[E_REJECTED_HIT]);
 #define WEAPON_HELIBLADES (WEAPON:50)
 #define WEAPON_EXPLOSION (WEAPON:51)
 #define WEAPON_CARPARK (WEAPON:52)
-#define WEAPON_UNKNOWN (WEAPON:55)
+
+#if defined WEAPON_UNKNOWN
+	#undef WEAPON_UNKNOWN
+	#define WEAPON_UNKNOWN (WEAPON:55)
+#endif
 
 #if !defined _INC_SKY
 	// Define packet IDs

--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -398,8 +398,8 @@ forward OnRejectedHit(playerid, hit[E_REJECTED_HIT]);
 
 #if defined WEAPON_UNKNOWN
 	#undef WEAPON_UNKNOWN
-	#define WEAPON_UNKNOWN (WEAPON:55)
 #endif
+#define WEAPON_UNKNOWN (WEAPON:55)
 
 #if !defined _INC_SKY
 	// Define packet IDs

--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -396,6 +396,7 @@ forward OnRejectedHit(playerid, hit[E_REJECTED_HIT]);
 #define WEAPON_EXPLOSION (WEAPON:51)
 #define WEAPON_CARPARK (WEAPON:52)
 
+// Possibly defined in omp-stdlib with a different value
 #if defined WEAPON_UNKNOWN
 	#undef WEAPON_UNKNOWN
 #endif


### PR DESCRIPTION
If it's already defined in any other libs (mainly in omp-stdlib), undef the old definition and define new one as it's critical for us to have exactly value 55 because weapon-config assumes this ID in many internal checks (omp-stdlib's `WEAPON_UNKNOWN` is -1, so we cannot keep using it). We also cannot rename this definition in wc to any other name because users may have it added in their scripts.

I still think omp-stdlib should've been changed it on their side before it was merged into the latest omp server release, as it was obviously added without any decent testing with any popular libs which might already have this definition (like in our case, in weapon-config for years), but it's highly unlikely that anything can be done now on stdlib side, since in that case it will break compatibility for those who started using `WEAPON_UNKNOWN` from the current version of stdlib.

So, having two same definition names for different values under the hood, I think the least bad way to solve it is to "forget" the stdlib value and redefine with our value. Basically, it's exactly what happens now, but now users have useless `warning 201: redefinition of constant/macro`.