### PR TITLE
Remove redundant resetting

### DIFF
--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -2901,10 +2901,6 @@ public OnPlayerConnect(playerid)
 	#if !defined _INC_SKY
 		s_FakeHealth{playerid} = 255;
 		s_FakeArmour{playerid} = 255;
-		s_FakeQuat[playerid][0] = Float:0x7FFFFFFF;
-		s_FakeQuat[playerid][1] = Float:0x7FFFFFFF;
-		s_FakeQuat[playerid][2] = Float:0x7FFFFFFF;
-		s_FakeQuat[playerid][3] = Float:0x7FFFFFFF;
 		s_TempDataWritten[playerid] = false;
 		s_SyncDataFrozen[playerid] = false;
 		s_GogglesUsed[playerid] = 0;

--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -3573,7 +3573,11 @@ public OnPlayerKeyStateChange(playerid, KEY:newkeys, KEY:oldkeys)
 		}
 	}
 
-	return WC_OnPlayerKeyStateChange(playerid, newkeys, oldkeys);
+	if (!s_IsDying[playerid]) {
+		return WC_OnPlayerKeyStateChange(playerid, newkeys, oldkeys);
+	} else {
+		return 0;
+	}
 }
 
 public OnPlayerStreamIn(playerid, forplayerid)


### PR DESCRIPTION
1. Remove manual resetting of `s_FakeQuat` array in `OnPlayerConnect`, since right below in the same callback we anyway call `SetFakeFacingAngle(playerid, _)` which does the same.
2. Block `OnPlayerKeyStateChange` in case of serverside death, if it's somehow called by samp server.