### PR TITLE
Vehicle model checks and double death

### DIFF
--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -6019,6 +6019,10 @@ static InflictDamage(playerid, Float:amount, issuerid = INVALID_PLAYER_ID, WEAPO
 		if (s_CbugAllowed[playerid]) {
 			WC_OnPlayerDeath(playerid, issuerid, weaponid);
 		} else {
+			if (s_DelayedDeathTimer[playerid]) {
+				KillTimer(s_DelayedDeathTimer[playerid]);
+			}
+
 			s_DelayedDeathTimer[playerid] = SetTimerEx(#WC_DelayedDeath, 1200, false, "iii", playerid, issuerid, weaponid);
 		}
 	}
@@ -6028,7 +6032,10 @@ static InflictDamage(playerid, Float:amount, issuerid = INVALID_PLAYER_ID, WEAPO
 
 forward WC_DelayedDeath(playerid, issuerid, WEAPON:reason);
 public WC_DelayedDeath(playerid, issuerid, WEAPON:reason) {
-	s_DelayedDeathTimer[playerid] = 0;
+	if (s_DelayedDeathTimer[playerid]) {
+		KillTimer(s_DelayedDeathTimer[playerid]);
+		s_DelayedDeathTimer[playerid] = 0;
+	}
 
 	WC_OnPlayerDeath(playerid, issuerid, reason);
 }

--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -4254,16 +4254,14 @@ public OnPlayerTakeDamage(playerid, issuerid, Float:amount, WEAPON:weaponid, bod
 		if (issuerid != INVALID_PLAYER_ID
 		&& (weaponid == WEAPON_M4 || weaponid == WEAPON_MINIGUN)
 		&& GetPlayerState(issuerid) == PLAYER_STATE_DRIVER) {
-			new modelid = GetVehicleModel(GetPlayerVehicleID(issuerid));
+			new vehicleid = GetPlayerVehicleID(issuerid);
 
-			if (weaponid == WEAPON_M4) {
-				if (modelid == 447 || modelid == 464 || modelid == 476) {
-					weaponid = WEAPON_VEHICLE_M4;
+			if (IsVehicleArmedWithWeapon(vehicleid, weaponid)) {
+				if (weaponid == WEAPON_MINIGUN) {
+					weaponid = WEAPON_VEHICLE_MINIGUN;
 				} else {
-					return 0;
+					weaponid = WEAPON_VEHICLE_M4;
 				}
-			} else if (weaponid == WEAPON_MINIGUN && modelid == 425) {
-				weaponid = WEAPON_VEHICLE_MINIGUN;
 			} else {
 				return 0;
 			}
@@ -5154,7 +5152,7 @@ static HasSameTeam(playerid, otherid)
 	return (s_PlayerTeam[playerid] == s_PlayerTeam[otherid]);
 }
 
-static Float:WC_Bar_Calculate(Float:width, Float:max, Float:value)
+static Float:WC_CalculateBar(Float:width, Float:max, Float:value)
 {
 	return ((width / max) * value);
 }
@@ -5219,7 +5217,7 @@ static UpdateHealthBar(playerid, bool:force = false)
 
 					PlayerTextDrawTextSize(playerid,
 						s_HealthBarForeground[playerid],
-						WC_Bar_Calculate(
+						WC_CalculateBar(
 						57.8,
 						100.0,
 						float(health)),
@@ -5233,7 +5231,7 @@ static UpdateHealthBar(playerid, bool:force = false)
 			} else if (s_InternalPlayerTextDraw[playerid][s_HealthBarForeground[playerid]]) {
 				PlayerTextDrawTextSize(playerid,
 					s_HealthBarForeground[playerid],
-					WC_Bar_Calculate(
+					WC_CalculateBar(
 					57.8,
 					100.0,
 					float(health)),
@@ -5334,16 +5332,47 @@ static UpdateSyncData(playerid)
 	}
 }
 
+static IsVehicleBike(vehicleid)
+{
+	switch (GetVehicleModel(vehicleid)) {
+		case 448, 461, 462, 463, 468, 471, 481,
+		     509, 510, 521, 522, 523, 581, 586: {
+			return true;
+		}
+	}
+
+	return false;
+}
+
+static IsVehicleArmedWithWeapon(vehicleid, WEAPON:weaponid)
+{
+	switch (GetVehicleModel(vehicleid)) {
+		case 425: {
+			return (weaponid == WEAPON_MINIGUN || weaponid == WEAPON_ROCKETLAUNCHER);
+		}
+
+		case 447, 464, 476: {
+			return (weaponid == WEAPON_M4);
+		}
+
+		case 432, 520: {
+			return (weaponid == WEAPON_ROCKETLAUNCHER);
+		}
+	}
+
+	return false;
+}
+
 static WasPlayerInVehicle(playerid, time) {
 	if (!s_LastVehicleTick[playerid]) {
-		return 0;
+		return false;
 	}
 
 	if (GetTickCount() - time < s_LastVehicleTick[playerid]) {
-		return 1;
+		return true;
 	}
 
-	return 0;
+	return false;
 }
 
 #if WC_CUSTOM_VENDING_MACHINES
@@ -5587,18 +5616,18 @@ static ProcessDamage(&playerid, &issuerid, &Float:amount, &WEAPON:weaponid, &bod
 		// Figure out what caused the explosion
 		if (issuerid != INVALID_PLAYER_ID) {
 			if (GetPlayerState(issuerid) == PLAYER_STATE_DRIVER) {
-				new modelid = GetVehicleModel(GetPlayerVehicleID(issuerid));
+				new vehicleid = GetPlayerVehicleID(issuerid);
 
-				if (modelid == 425 || modelid == 432 || modelid == 520) {
+				if (IsVehicleArmedWithWeapon(vehicleid, WEAPON_ROCKETLAUNCHER)) {
 					weaponid = WEAPON_VEHICLE_ROCKETLAUNCHER;
 				}
 			} else if (s_LastExplosive[issuerid]) {
 				weaponid = s_LastExplosive[issuerid];
 			}
 		} else if (GetPlayerState(playerid) == PLAYER_STATE_DRIVER) {
-			new modelid = GetVehicleModel(GetPlayerVehicleID(playerid));
+			new vehicleid = GetPlayerVehicleID(playerid);
 
-			if (modelid == 425 || modelid == 432 || modelid == 520) {
+			if (IsVehicleArmedWithWeapon(vehicleid, WEAPON_ROCKETLAUNCHER)) {
 				weaponid = WEAPON_VEHICLE_ROCKETLAUNCHER;
 			}
 		}
@@ -5924,34 +5953,26 @@ static InflictDamage(playerid, Float:amount, issuerid = INVALID_PLAYER_ID, WEAPO
 		new vehicleid = GetPlayerVehicleID(playerid);
 
 		if (vehicleid) {
-			new modelid = GetVehicleModel(vehicleid);
-			new seat = GetPlayerVehicleSeat(playerid);
-
 			TogglePlayerControllable(playerid, false);
 
-			switch (modelid) {
-				case 509, 481, 510, 462, 448, 581, 522,
-				     461, 521, 523, 463, 586, 468, 471: {
-					new Float:vx, Float:vy, Float:vz;
-					GetVehicleVelocity(vehicleid, vx, vy, vz);
+			if (IsVehicleBike(vehicleid)) {
+				new Float:vx, Float:vy, Float:vz;
+				GetVehicleVelocity(vehicleid, vx, vy, vz);
 
-					if (vx * vx + vy * vy + vz * vz >= 0.4) {
-						animname = "BIKE_fallR";
-						PlayerDeath(playerid, animlib, animname, false);
-					} else {
-						animname = "BIKE_fall_off";
-						PlayerDeath(playerid, animlib, animname, false);
-					}
+				if (vx * vx + vy * vy + vz * vz >= 0.4) {
+					animname = "BIKE_fallR";
+					PlayerDeath(playerid, animlib, animname, false);
+				} else {
+					animname = "BIKE_fall_off";
+					PlayerDeath(playerid, animlib, animname, false);
 				}
-
-				default: {
-					if (seat & 1) {
-						animname = "CAR_dead_LHS";
-						PlayerDeath(playerid, animlib, animname);
-					} else {
-						animname = "CAR_dead_RHS";
-						PlayerDeath(playerid, animlib, animname);
-					}
+			} else {
+				if (GetPlayerVehicleSeat(playerid) & 1) {
+					animname = "CAR_dead_LHS";
+					PlayerDeath(playerid, animlib, animname);
+				} else {
+					animname = "CAR_dead_RHS";
+					PlayerDeath(playerid, animlib, animname);
 				}
 			}
 		} else if (GetPlayerSpecialAction(playerid) == SPECIAL_ACTION_USEJETPACK) {

--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -3051,6 +3051,11 @@ public OnPlayerSpawn(playerid)
 	s_TrueDeath[playerid] = false;
 	s_InClassSelection[playerid] = false;
 
+	if (s_DeathTimer[playerid]) {
+		KillTimer(s_DeathTimer[playerid]);
+		s_DeathTimer[playerid] = 0;
+	}
+
 	if (s_ForceClassSelection[playerid]) {
 		DebugMessage(playerid, "Being forced into class selection");
 		ForceClassSelection(playerid);
@@ -3131,11 +3136,6 @@ public OnPlayerSpawn(playerid)
 		GetPlayerFacingAngle(playerid, s_PlayerFallbackSpawnInfo[playerid][e_Rot]);
 	}
 
-	if (s_DeathTimer[playerid]) {
-		KillTimer(s_DeathTimer[playerid]);
-		s_DeathTimer[playerid] = 0;
-	}
-
 	if (s_IsDying[playerid]) {
 		s_IsDying[playerid] = false;
 
@@ -3199,6 +3199,11 @@ public OnPlayerRequestClass(playerid, classid)
 {
 	DebugMessage(playerid, "Requested class: %d", classid);
 
+	if (s_DeathTimer[playerid]) {
+		KillTimer(s_DeathTimer[playerid]);
+		s_DeathTimer[playerid] = 0;
+	}
+
 	if (s_DeathSkip[playerid]) {
 		DebugMessage(playerid, "Skipping death - class selection skipped");
 		SpawnPlayer(playerid);
@@ -3216,11 +3221,6 @@ public OnPlayerRequestClass(playerid, classid)
 		SpawnPlayerInPlace(playerid);
 
 		return 0;
-	}
-
-	if (s_DeathTimer[playerid]) {
-		KillTimer(s_DeathTimer[playerid]);
-		s_DeathTimer[playerid] = 0;
 	}
 
 	if (s_IsDying[playerid]) {
@@ -3282,7 +3282,18 @@ public OnPlayerDeath(playerid, killerid, WEAPON:reason)
 		}
 	#endif
 
+	if (s_DeathTimer[playerid]) {
+		KillTimer(s_DeathTimer[playerid]);
+		s_DeathTimer[playerid] = 0;
+	}
+
 	if (s_BeingResynced[playerid] || s_ForceClassSelection[playerid]) {
+		return 1;
+	}
+
+	if (s_IsDying[playerid]) {
+		DebugMessageRedAll("death while dying %d", playerid);
+
 		return 1;
 	}
 
@@ -3292,17 +3303,6 @@ public OnPlayerDeath(playerid, killerid, WEAPON:reason)
 	}
 
 	DebugMessageRedAll("OnPlayerDeath(%d died by %d from %d)", playerid, reason, killerid);
-
-	if (s_DeathTimer[playerid]) {
-		KillTimer(s_DeathTimer[playerid]);
-		s_DeathTimer[playerid] = 0;
-	}
-
-	if (s_IsDying[playerid]) {
-		DebugMessageRedAll("death while dying %d", playerid);
-
-		return 1;
-	}
 
 	if (reason < WEAPON_UNARMED || reason > WEAPON_UNKNOWN) {
 		reason = WEAPON_UNKNOWN;

--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -1908,6 +1908,11 @@ stock WC_TogglePlayerSpectating(playerid, toggle)
 {
 	if (TogglePlayerSpectating(playerid, !!toggle)) {
 		if (toggle) {
+			if (s_DelayedDeathTimer[playerid]) {
+				KillTimer(s_DelayedDeathTimer[playerid]);
+				s_DelayedDeathTimer[playerid] = 0;
+			}
+
 			if (s_DeathTimer[playerid]) {
 				KillTimer(s_DeathTimer[playerid]);
 				s_DeathTimer[playerid] = 0;
@@ -6033,6 +6038,11 @@ static PlayerDeath(playerid, animlib[32], animname[32], bool:anim_lock = false, 
 	s_PlayerHealth[playerid] = 0.0;
 	s_PlayerArmour[playerid] = 0.0;
 	s_IsDying[playerid] = true;
+
+	if (s_DelayedDeathTimer[playerid]) {
+		KillTimer(s_DelayedDeathTimer[playerid]);
+		s_DelayedDeathTimer[playerid] = 0;
+	}
 
 	#if defined _INC_open_mp
 		if (IsPlayerTeleportAllowed(playerid)) {


### PR DESCRIPTION
This PR prevents the most of possibilities when players could die and spawn twice because of some unusual circumstances, for example when `s_DeathTimer` or `s_DelayedDeathTimer` didn't destroyed for some reason but weren't relevant anymore, so their calling might lead to double spawn. It also vastly improves any vehicle model checks like those for weaponized vehicles or the one for bikes (now it's all moved to a separate functions as it should be).