### PR TITLE
Ignoring SKY for open.mp

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@ It's pretty much plug-and-play if you don't have any filterscripts that interfer
 
 ## Requirements
 
-This include file requires the [SKY](https://github.com/oscar-broman/SKY/) or [Pawn.RakNet](https://github.com/katursis/Pawn.RakNet/) plugin.
+This include file requires [SKY](https://github.com/oscar-broman/SKY/) or [Pawn.RakNet](https://github.com/katursis/Pawn.RakNet/) plugin.
 
-**Note:** SKY has a higher priority if the user has not included any of these dependencies before weapon-config (it will automatically try to include SKY and only then Pawn.RakNet, if fail with the first). Also, SKY will take precedence if both dependencies are included (it will use the SKY plugin instead of Pawn.RakNet).
+**Note:** SKY has a higher priority if the user has not included any of these dependencies before weapon-config (it will automatically try to include SKY and only then Pawn.RakNet, if fail with the first). Also, SKY will take precedence if both dependencies are included (it will use SKY plugin instead of Pawn.RakNet).
 
 # Features
 

--- a/pawn.json
+++ b/pawn.json
@@ -2,5 +2,8 @@
   "user": "oscar-broman",
   "repo": "samp-weapon-config",
   "contributors": ["oscar-broman"],
-  "dependencies": ["sampctl/samp-stdlib", "oscar-broman/SKY:2.3.2"]
+  "dependencies": [
+    "sampctl/samp-stdlib",
+    "oscar-broman/SKY:2.3.2"
+  ]
 }

--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -83,7 +83,14 @@
 	#error streamer.inc is required when WC_USE_STREAMER=true
 #endif
 
-#if !defined _INC_SKY && !defined PAWNRAKNET_INC_
+#if defined _INC_open_mp
+	// https://github.com/katursis/Pawn.RakNet
+	#tryinclude <Pawn.RakNet>
+
+	#if !defined PAWNRAKNET_INC_
+		#error Pawn.RakNet plugin is required
+	#endif
+#elseif !defined _INC_SKY && !defined PAWNRAKNET_INC_
 	// https://github.com/oscar-broman/SKY
 	#tryinclude <SKY>
 
@@ -92,7 +99,7 @@
 		#tryinclude <Pawn.RakNet>
 
 		#if !defined PAWNRAKNET_INC_
-			#error The SKY or Pawn.RakNet plugin is required
+			#error SKY or Pawn.RakNet plugin is required
 		#endif
 	#endif
 #endif


### PR DESCRIPTION
This fixes the case when the user has both SKY and Pawn.RakNet include files in his dependencies folder, but being on open.mp he doesn't use SKY anymore. Since weapon-config automatically tries to include one of the dependencies and SKY has always primarily chosen over Pawn.RakNet, that user could have a problem when he started omp server about some natives which wasn't found (and they're from SKY obviously). This case could lead to little inconveniences so it's now solved by checking at compile time "if omp libs are used, try to include only Pawn.RakNet as our main dependency".

Btw, I also made a couple of tiny corrections in readme and pawn.json to correct some syntax issues.