### PR TITLE
Fix stun animation bugs

### DIFF
--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -3449,7 +3449,7 @@ public OnPlayerDeath(playerid, killerid, WEAPON:reason)
 		}
 	}
 
-	UpdateHealthBar(playerid);
+	UpdateHealthBar(playerid, .forcesync = true);
 
 	return 1;
 }
@@ -5186,7 +5186,7 @@ static Float:WC_CalculateBar(Float:width, Float:max, Float:value)
 	return ((width / max) * value);
 }
 
-static UpdateHealthBar(playerid, bool:force = false)
+static UpdateHealthBar(playerid, bool:force = false, bool:forcesync = false)
 {
 	if (s_BeingResynced[playerid] || s_ForceClassSelection[playerid]) {
 		return;
@@ -5222,7 +5222,9 @@ static UpdateHealthBar(playerid, bool:force = false)
 	SetFakeHealth(playerid, health);
 	SetFakeArmour(playerid, armour);
 
-	UpdateSyncData(playerid);
+	if (forcesync || WC_IsPlayerPaused(playerid)) {
+		UpdateSyncData(playerid);
+	}
 
 	if (health != s_LastSentHealth[playerid]) {
 		s_LastSentHealth[playerid] = health;
@@ -5344,6 +5346,8 @@ static UpdateSyncData(playerid)
 		return;
 	}
 
+	new anim = GetPlayerAnimationIndex(playerid);
+
 	#if defined _Y_ITERATE_LOCAL_VERSION && defined _FOREACH_STREAMED && !defined FOREACH_NO_STREAMED
 	foreach (new i : StreamedPlayer[playerid]) {
 	#elseif defined _Y_ITERATE_LOCAL_VERSION || defined _FOREACH_LOCAL_VERSION
@@ -5352,10 +5356,10 @@ static UpdateSyncData(playerid)
 	for (new i = 0; i != MAX_PLAYERS; i++) {
 	#endif
 		#if defined _Y_ITERATE_LOCAL_VERSION && defined _FOREACH_STREAMED && !defined FOREACH_NO_STREAMED
-		SendLastSyncPacket(playerid, i);
+		SendLastSyncPacket(playerid, i, .animation = anim);
 		#else
 		if (i != playerid && IsPlayerStreamedIn(playerid, i)) {
-			SendLastSyncPacket(playerid, i);
+			SendLastSyncPacket(playerid, i, .animation = anim);
 		}
 		#endif
 	}
@@ -6129,7 +6133,7 @@ static PlayerDeath(playerid, animlib[32], animname[32], bool:anim_lock = false, 
 
 	OnPlayerPrepareDeath(playerid, animlib, animname, anim_lock, respawn_time);
 
-	UpdateHealthBar(playerid);
+	UpdateHealthBar(playerid, .forcesync = true);
 	FreezeSyncPacket(playerid, .toggle = freeze_sync);
 
 	if (respawn_time == -1) {


### PR DESCRIPTION
This PR fixes an old but still relevant issue with stun animation bugs due to force sending onfoot packet by `UpdateSyncData` function (which is called inside `UpdateHealthBar`, which in turn called in almost every place when player's health change or he takes any damage). We cannot just cut off `UpdateSyncData` entirely because it provides a feature with always correct healthbars for others (even when player in AFK) by emulating an onfoot packet from this player with latest health and armour.

So, we will forcefully send extra onfoot packet (i.e. we will call `UpdateSyncData` in `UpdateHealthBar`) only when player is in AFK or when he's dying, since it's a critical place where his state should be updated immediately. Otherwise no extra packet emulation will be applied and the player will update his healthbar in the next packet he send by himself. This is rather general improvement not only to fix stun anim interruptions, but also to omit unnecessary packet emulations if players not in AFK and thus will anyway update their health data very soon after it was set.

The complete solution is the second move which also adds this PR: fix the animation ID passed in emulated onfoot packet, setting it to the current one the player actually performs now. This way, even if he will be in AFK with some animation being performed, calling `UpdateSyncData` won't break his anim, will it be a clientside one or set by the server.