### PR TITLE
Add configurable anti-cbug death delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,4 +400,4 @@ Show or hide health bar for player
 SetCbugDeathDelay(bool:toggle);
 ```
 
-Toggles a 1.2-second delay on player death to verify that the last shot was not fired using a cbug. This setting has no effect if cbug is allowed.
+Toggles a 1.2-second delay on player death to verify that the last shot was not fired using a cbug (enabled by default). This setting has no effect if cbug is allowed.

--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -1027,7 +1027,7 @@ static Float:s_LastZ[MAX_PLAYERS] = {0.0, ...};
 static s_LastStopTick[MAX_PLAYERS];
 
 static bool:s_CbugGlobal = true;
-static bool:s_CbugDeathDelay = false;
+static bool:s_CbugDeathDelay = true;
 static bool:s_CbugAllowed[MAX_PLAYERS] = {true, ...};
 static s_CbugFroze[MAX_PLAYERS];
 


### PR DESCRIPTION
Currently weapon-config delays every death caused by players with cbug disabled by 1.2-second to make sure, that the player didn't use cbug for that kill. It looks really weird for the killer and I doubt anyone would want to verify that last shot at the expense of what looks like server lag.

This PR adds a native that allows to toggle that behavior (it's disabled by default).

Yes, it might be a behavior difference if anyone relies on it, the default can always be changed from `false` to `true` if necessary.