### PR TITLE
Fix animation set in `SendLastSyncPacket`

### DIFF
--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -3623,7 +3623,7 @@ public OnPlayerStreamIn(playerid, forplayerid)
 {
 	// Send ped floor_hit_f
 	if (s_IsDying[playerid] || s_InClassSelection[playerid]) {
-		SendLastSyncPacket(playerid, forplayerid, .animation = 0x2e040000 + 1150);
+		SendLastSyncPacket(playerid, forplayerid, .animation = 0x2e040000 + 1151);
 	}
 
 	return WC_OnPlayerStreamIn(playerid, forplayerid);
@@ -4951,7 +4951,7 @@ IPacket:WC_AIM_SYNC(playerid, BitStream:bs)
 
 #if defined _INC_open_mp
 
-// The alternative is to `SetPlayerAdmin` to `false` on death, but this doesn't seem like the "safest" solution
+// The alternative is `SetPlayerAdmin` to `false` on death, but this doesn't seem like the "safest" solution
 ORPC:WC_RPC_SET_POS_FIND_Z(playerid, BitStream:bs)
 {
 	if (s_BlockAdminTeleport[playerid]) {
@@ -4962,9 +4962,9 @@ ORPC:WC_RPC_SET_POS_FIND_Z(playerid, BitStream:bs)
 	return 1;
 }
 
-#endif
+#endif // _INC_open_mp
 
-#endif
+#endif // _INC_SKY
 
 /*
  * Internal functions
@@ -5346,8 +5346,6 @@ static UpdateSyncData(playerid)
 		return;
 	}
 
-	new anim = GetPlayerAnimationIndex(playerid);
-
 	#if defined _Y_ITERATE_LOCAL_VERSION && defined _FOREACH_STREAMED && !defined FOREACH_NO_STREAMED
 	foreach (new i : StreamedPlayer[playerid]) {
 	#elseif defined _Y_ITERATE_LOCAL_VERSION || defined _FOREACH_LOCAL_VERSION
@@ -5356,10 +5354,10 @@ static UpdateSyncData(playerid)
 	for (new i = 0; i != MAX_PLAYERS; i++) {
 	#endif
 		#if defined _Y_ITERATE_LOCAL_VERSION && defined _FOREACH_STREAMED && !defined FOREACH_NO_STREAMED
-		SendLastSyncPacket(playerid, i, .animation = anim);
+		SendLastSyncPacket(playerid, i);
 		#else
 		if (i != playerid && IsPlayerStreamedIn(playerid, i)) {
-			SendLastSyncPacket(playerid, i, .animation = anim);
+			SendLastSyncPacket(playerid, i);
 		}
 		#endif
 	}
@@ -6797,9 +6795,9 @@ static SendLastSyncPacket(playerid, toplayerid, animation = 0)
 	}
 
 	// Animations are only sent when they are changed
-	if (!animation) {
-		s_LastSyncData[playerid][PR_animationId] = 0;
-		s_LastSyncData[playerid][PR_animationFlags] = 0;
+	if (animation) {
+		s_LastSyncData[playerid][PR_animationId] = animation & 0xFFFF;
+		s_LastSyncData[playerid][PR_animationFlags] = (animation >> 16) & 0xFFFF;
 	}
 
 	BS_WriteOnFootSync(bs, s_LastSyncData[playerid], true);
@@ -6824,7 +6822,7 @@ static ClearAnimationsForPlayer(playerid, forplayerid)
 	return 1;
 }
 
-#endif
+#endif // _INC_SKY
 
 forward WC_SecondKnifeAnim(playerid);
 public WC_SecondKnifeAnim(playerid)


### PR DESCRIPTION
The initial bug was encountered with this code:
https://github.com/oscar-broman/samp-weapon-config/blob/049f7f2f76b3a3d03367769f2fec5ae715b4f412/weapon-config.inc#L3624-L3627
when there was no dead animation when a dead player streamed in for another player. A bug was in both implementations (code powered by SKY and Pawn.RakNet plugin) and was recently fixed in SKY itself.

Now the same fix comes to the Pawn.RakNet wrapper implementation, setting the animation properly, considering animflags and rewriting it only when it was passed as not 0 to `SendLastSyncPacket` function (thus it keeps the same behavior like what SKY implementation does).

The animation of a dead player were corrected to `floor_hit_f` instead of `floor_hit` like it should've been done initially.
Also some minor improvements to readability for large ifdef code blocks to understand where they ends.