### PR TITLE
Additional bodypart check

### DIFF
--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -4310,7 +4310,9 @@ public OnPlayerTakeDamage(playerid, issuerid, Float:amount, WEAPON:weaponid, bod
 			return 0;
 		}
 
-		if (s_IsDying[issuerid] && (IsBulletWeapon(weaponid) || IsMeleeWeapon(weaponid)) && GetTickCount() - s_LastDeathTick[issuerid] > 80) {
+		if (s_IsDying[issuerid]
+		&& (IsBulletWeapon(weaponid) || IsMeleeWeapon(weaponid) || WEAPON_VEHICLE_M4 <= weaponid <= WEAPON_VEHICLE_MINIGUN)
+		&& GetTickCount() - s_LastDeathTick[issuerid] > 80) {
 			DebugMessageRed(playerid, "shot/punched by dead player (%d)", issuerid);
 			return 0;
 		}

--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -5589,7 +5589,9 @@ static ProcessDamage(&playerid, &issuerid, &Float:amount, &WEAPON:weaponid, &bod
 	}
 
 	// Only torso from non-bullet weapons
-	if (!IsBulletWeapon(weaponid) && bodypart != 3) {
+	if (!IsBulletWeapon(weaponid)
+		&& !(WEAPON_VEHICLE_M4 <= weaponid <= WEAPON_VEHICLE_MINIGUN)
+		&& bodypart != 3) {
 		return WC_INVALID_DAMAGE;
 	}
 

--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -3784,14 +3784,12 @@ public OnPlayerUpdate(playerid)
 				new animlib[] = "PED", animname[] = "IDLE_stance";
 				ApplyAnimation(playerid, animlib, animname, 4.1, true, false, false, false, 1, FORCE_SYNC:1);
 			}
-		} else {
-			if (GetPlayerAnimationIndex(playerid) != 1189) {
-				s_DeathSkip[playerid] = 0;
+		} else if (GetPlayerAnimationIndex(playerid) != 1189) {
+			s_DeathSkip[playerid] = 0;
 
-				WC_DeathSkipEnd(playerid);
+			WC_DeathSkipEnd(playerid);
 
-				DebugMessage(playerid, "Death skip end");
-			}
+			DebugMessage(playerid, "Death skip end");
 		}
 	}
 
@@ -5590,6 +5588,11 @@ static ProcessDamage(&playerid, &issuerid, &Float:amount, &WEAPON:weaponid, &bod
 		weaponid = WEAPON_CARPARK;
 	}
 
+	// Only torso from non-bullet weapons
+	if (!IsBulletWeapon(weaponid) && bodypart != 3) {
+		return WC_INVALID_DAMAGE;
+	}
+
 	// Finish processing drown/fire/carpark quickly, since they are sent at very high rates
 	if (IsHighRateWeapon(weaponid)) {
 		// Apply reasonable bounds
@@ -5620,11 +5623,9 @@ static ProcessDamage(&playerid, &issuerid, &Float:amount, &WEAPON:weaponid, &bod
 					AddRejectedHit(issuerid, playerid, HIT_TOO_FAR_FROM_ORIGIN, WEAPON:weaponid, _:dist);
 					return WC_INVALID_DISTANCE;
 				}
-			} else {
-				if (dist > s_WeaponRange[weaponid] + 2.0) {
-					AddRejectedHit(issuerid, playerid, HIT_TOO_FAR_FROM_ORIGIN, WEAPON:weaponid, _:dist, _:s_WeaponRange[weaponid]);
-					return WC_INVALID_DISTANCE;
-				}
+			} else if (dist > s_WeaponRange[weaponid] + 2.0) {
+				AddRejectedHit(issuerid, playerid, HIT_TOO_FAR_FROM_ORIGIN, WEAPON:weaponid, _:dist, _:s_WeaponRange[weaponid]);
+				return WC_INVALID_DISTANCE;
 			}
 		}
 


### PR DESCRIPTION
Hanging around [gta-reversed](https://github.com/gta-reversed/gta-reversed) repo, I've noticed that some specific damage types are always processed with a fixed bodypart which is always 3 (torso), like [here](https://github.com/gta-reversed/gta-reversed/blob/master/source/game_sa/Tasks/TaskTypes/TaskSimpleSwim.cpp#L198), [here](https://github.com/gta-reversed/gta-reversed/blob/master/source/game_sa/Tasks/TaskTypes/TaskSimplePlayerOnFire.cpp#L52) or [here](https://github.com/gta-reversed/gta-reversed/blob/master/source/game_sa/Tasks/TaskTypes/TaskSimpleHurtPedWithCar.cpp#L43). Then I started to find more about that to form a list of weapons where bodypart is always passed as torso, and figured out it's the most of damage reasons, including melee weapons (and even including stealth kill from knife). In other words, anything except bullet weapons aren't sending anything than torso as bodypart, which I considered interesting to add here as another validation check against damagers which can pass some random bodyparts when spoofing the damage.