### PR TITLE
Update Health Bar when setting max health/armor

### DIFF
--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -1508,6 +1508,7 @@ stock SetPlayerMaxHealth(playerid, Float:value)
 {
 	if (0 <= playerid < MAX_PLAYERS) {
 		s_PlayerMaxHealth[playerid] = value;
+		UpdateHealthBar(playerid, true);
 	}
 }
 
@@ -1515,6 +1516,7 @@ stock SetPlayerMaxArmour(playerid, Float:value)
 {
 	if (0 <= playerid < MAX_PLAYERS) {
 		s_PlayerMaxArmour[playerid] = value;
+		UpdateHealthBar(playerid, true);
 	}
 }
 


### PR DESCRIPTION
I noticed that when you set the maximum health/armor of player, the health bar doesn't update