### PR TITLE
Consistent default param values, other minor fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,9 +296,9 @@ SetDamageFeedForPlayer(playerid, toggle = -1);
 Toggle damage feed for player
 
 ```pawn
-IsDamageFeedActive(playerid = -1);
+IsDamageFeedActive(playerid = INVALID_PLAYER_ID);
 ```
-Returns true if damage feed is active for player (for all, if `playerid` passed as -1)
+Returns true if damage feed is active for player (for all, if `playerid` passed as INVALID_PLAYER_ID)
 
 ```pawn
 SetDamageSounds(taken, given);

--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -1149,6 +1149,10 @@ stock IsMeleeWeapon(WEAPON:weaponid)
 
 stock WC_IsPlayerSpawned(playerid)
 {
+	if (playerid < 0 || playerid >= MAX_PLAYERS) {
+		return false;
+	}
+
 	if (s_IsDying[playerid] || s_BeingResynced[playerid]) {
 		return false;
 	}
@@ -1702,6 +1706,10 @@ stock WC_SpawnPlayer(playerid)
 
 stock PLAYER_STATE:WC_GetPlayerState(playerid)
 {
+	if (playerid < 0 || playerid >= MAX_PLAYERS) {
+		return PLAYER_STATE_NONE;
+	}
+
 	if (s_IsDying[playerid]) {
 		return PLAYER_STATE_WASTED;
 	}

--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -5782,8 +5782,10 @@ static ProcessDamage(&playerid, &issuerid, &Float:amount, &WEAPON:weaponid, &bod
 		GetPlayerPos(issuerid, x, y, z);
 		dist = GetPlayerDistanceFromPoint(playerid, x, y, z);
 
-		if (_:WEAPON_UNARMED <= _:weaponid < sizeof(s_WeaponRange) && dist > s_WeaponRange[weaponid] + 2.0) {
-			AddRejectedHit(issuerid, playerid, HIT_TOO_FAR_FROM_ORIGIN, WEAPON:weaponid, _:dist, _:s_WeaponRange[weaponid]);
+		new WEAPON:reason = (weaponid == WEAPON_PISTOLWHIP) ? WEAPON_UNARMED : weaponid;
+
+		if (_:WEAPON_UNARMED <= _:reason < sizeof(s_WeaponRange) && dist > s_WeaponRange[reason] + 2.0) {
+			AddRejectedHit(issuerid, playerid, HIT_TOO_FAR_FROM_ORIGIN, WEAPON:weaponid, _:dist, _:s_WeaponRange[reason]);
 			return WC_INVALID_DISTANCE;
 		}
 	}

--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -1437,7 +1437,7 @@ stock SetDamageFeedForPlayer(playerid, toggle = -1)
 	return 0;
 }
 
-stock IsDamageFeedActive(playerid = -1)
+stock IsDamageFeedActive(playerid = INVALID_PLAYER_ID)
 {
 	if (0 <= playerid < MAX_PLAYERS) {
 		return s_DamageFeedPlayer[playerid] == 1 || s_DamageFeed && s_DamageFeedPlayer[playerid] != 0;


### PR DESCRIPTION
Problem/inconsistency:
Some functions document that you should pass `playerid` as -1 to achieve global (not per-player) impact, some others declare INVALID_PLAYER_ID. The second is preferable to make it the standart for all such functions.

So this PR lets consistently check for the same stub value everywhere, and since the previous validation improvements, it won't break any scripts which call weapon-config's functions with the old value `-1`, because now any functions (which have per-player or global effect depending on `playerid` param value) take any invalid player ID as the case to perform global effect.