### PR TITLE
One more couple of important fixes

### DIFF
--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -3128,7 +3128,7 @@ public OnPlayerSpawn(playerid)
 	if (s_BeingResynced[playerid]) {
 		s_BeingResynced[playerid] = false;
 
-		UpdateHealthBar(playerid);
+		UpdateHealthBar(playerid, true);
 
 		SetPlayerPos(playerid, s_SyncData[playerid][e_PosX], s_SyncData[playerid][e_PosY], s_SyncData[playerid][e_PosZ]);
 		SetPlayerFacingAngle(playerid, s_SyncData[playerid][e_PosA]);

--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -5609,6 +5609,18 @@ static ProcessDamage(&playerid, &issuerid, &Float:amount, &WEAPON:weaponid, &bod
 	// Car parking
 	if (weaponid == WEAPON_HELIBLADES && _:amount != _:330.0) {
 		weaponid = WEAPON_CARPARK;
+	} else if (WEAPON_VEHICLE <= weaponid <= WEAPON_HELIBLADES) {
+		if (issuerid != INVALID_PLAYER_ID) {
+			new Float:x, Float:y, Float:z, Float:dist;
+
+			GetPlayerPos(issuerid, x, y, z);
+			dist = GetPlayerDistanceFromPoint(playerid, x, y, z);
+
+			if (dist > 15.0) {
+				AddRejectedHit(issuerid, playerid, HIT_TOO_FAR_FROM_ORIGIN, WEAPON:weaponid, _:dist);
+				return WC_INVALID_DISTANCE;
+			}
+		}
 	}
 
 	// Only torso from non-bullet weapons


### PR DESCRIPTION
This PR probably have the final changes for known issues which I forgot about (they were applied in some private versions on servers I work), and since it's applicable for everyone, I suppose it's good additions here and harmless to be shared.

1. Minor fix for health amount when re-spawning after resync (when you've been silently killed by knife). Calling `UpdateHealthBar` without 'force = true' might give the player just default health amounts like 100.0 instead of 8000000.0 + 100.0, so the risks of facing client death were higher in that case.
2. Major fix for spoofing damage from `WEAPON_VEHICLE` with amount of 9.9, or `WEAPON_HELIBLADES` with amount of 330.0 if being in vehicle for all players nearby. The problem is that if you bypass [this check](https://github.com/oscar-broman/samp-weapon-config/blob/7c109778aaf428e59bd79571204e3a9900d87867/weapon-config.inc#L5609-L5612) by keeping the damage reason as is, not converting it to custom reason `WEAPON_CARPARK`, then no distance validation from [here](https://github.com/oscar-broman/samp-weapon-config/blob/7c109778aaf428e59bd79571204e3a9900d87867/weapon-config.inc#L5647) ever applies for this damage. Initial way of fixing it was just one-line modification of this check:
```pawn
if (weaponid == WEAPON_HELIBLADES && _:amount != _:330.0) {
```
into this:
```pawn
if (WEAPON_VEHICLE <= weaponid <= WEAPON_HELIBLADES) {
```
but it was bad decision to propose here because it modified the whole logic of WEAPON_CARPARK and applied damage amount reductions breaking instant kill from real heli blades collision. After some rewriting I came to the current way and it's ok to be merged for any gamemode without regressions.