### PR TITLE
Fix incorrect Float tag on vending machine data array

### DIFF
--- a/weapon-config.inc
+++ b/weapon-config.inc
@@ -902,7 +902,7 @@ stock const g_WeaponName[57][WC_MAX_WEAPON_NAME] = {
 
 // Yes - this is every single one of them
 #if WC_CUSTOM_VENDING_MACHINES
-	static const Float:sc_VendingMachines[][E_VENDING_MACHINE] = {
+	static const sc_VendingMachines[][E_VENDING_MACHINE] = {
 		{955, 0, -862.82, 1536.60, 21.98, 0.00, 0.00, 180.00, -862.84, 1537.60},
 		{956, 0, 2271.72, -76.46, 25.96, 0.00, 0.00, 0.00, 2271.72, -77.46},
 		{955, 0, 1277.83, 372.51, 18.95, 0.00, 0.00, 64.00, 1278.73, 372.07},


### PR DESCRIPTION
Removes the unnecessary Float: tag from the sc_VendingMachines array declaration.